### PR TITLE
Added Protobuf Serialization Support for Kafka Send Node

### DIFF
--- a/LICENCE
+++ b/LICENCE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) oriolrius
+Copyright (c) 2026 YRoshcha (Protobuf + Schema Registry producer support)
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,22 @@
+MIT License
+
+Copyright (c) Oriol Rius
+Copyright (c) 2026 Yehor Roshcha
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/LICENSE
+++ b/LICENSE
@@ -1,22 +1,9 @@
-MIT License
+This distribution contains code under more than one license.
 
-Copyright (c) Oriol Rius
-Copyright (c) 2026 Yehor Roshcha
+Original work by Oriol Rius remains licensed under the MIT License; see
+LICENSE-MIT. Yehor Roshcha's fork modifications are licensed under the Apache
+License, Version 2.0; see LICENSE-APACHE.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+Files that combine original and fork code identify this with the SPDX expression
+MIT AND Apache-2.0. See NOTICE for the attribution and scope of the fork
+modifications.

--- a/LICENSE-APACHE
+++ b/LICENSE-APACHE
@@ -1,0 +1,79 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities that control, are controlled by, or are under common control with that entity. For the purposes of this definition, "control" means (i) the power, direct or indirect, to cause the direction or management of such entity, whether by contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including but not limited to software source code, documentation source, and configuration files.
+
+"Object" form shall mean any form resulting from mechanical transformation or translation of a Source form, including but not limited to compiled object code, generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made available under the License, as indicated by a copyright notice that is included in or attached to the work.
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that is based on (or derived from) the Work and for which the editorial revisions, annotations, elaborations, or other modifications represent, as a whole, an original work of authorship. For the purposes of this License, Derivative Works shall not include works that remain separable from, or merely link (or bind by name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version of the Work and any modifications or additions to that Work or Derivative Works thereof, that is intentionally submitted to Licensor for inclusion in the Work by the copyright owner or by an individual or Legal Entity authorized to submit on behalf of the copyright owner.
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf of whom a Contribution has been received by Licensor and subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable copyright license to reproduce, prepare Derivative Works of, publicly display, publicly perform, sublicense, and distribute the Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of this License, each Contributor hereby grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free, irrevocable (except as stated in this section) patent license to make, have made, use, offer to sell, sell, import, and otherwise transfer the Work, where such license applies only to those patent claims licensable by such Contributor that are necessarily infringed by their Contribution(s) alone or by combination of their Contribution(s) with the Work to which such Contribution(s) was submitted. If You institute patent litigation against any entity (including a cross-claim or counterclaim in a lawsuit) alleging that the Work or a Contribution incorporated within the Work constitutes direct or contributory patent infringement, then any patent licenses granted to You under this License for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the Work or Derivative Works thereof in any medium, with or without modifications, and in Source or Object form, provided that You meet the following conditions:
+
+(a) You must give any other recipients of the Work or Derivative Works a copy of this License; and
+
+(b) You must cause any modified files to carry prominent notices stating that You changed the files; and
+
+(c) You must retain, in the Source form of any Derivative Works that You distribute, all copyright, patent, trademark, and attribution notices from the Source form of the Work, excluding those notices that do not pertain to any part of the Derivative Works; and
+
+(d) If the Work includes a "NOTICE" text file as part of its distribution, then any Derivative Works that You distribute must include a readable copy of the attribution notices contained within such NOTICE file, excluding those notices that do not pertain to any part of the Derivative Works, in at least one of the following places: within a NOTICE text file distributed as part of the Derivative Works; within the Source form or documentation, if provided along with the Derivative Works; or, within a display generated by the Derivative Works, if and wherever such third-party notices normally appear. The contents of the NOTICE file are for informational purposes only and do not modify the License. You may add Your own attribution notices within Derivative Works that You distribute, alongside or as an addendum to the NOTICE text from the Work, provided that such additional attribution notices cannot be construed as modifying the License.
+
+You may add Your own copyright statement to Your modifications and may provide additional or different license terms and conditions for use, reproduction, or distribution of Your modifications, or for any such Derivative Works as a whole, provided Your use, reproduction, and distribution of the Work otherwise complies with the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise, any Contribution intentionally submitted for inclusion in the Work by You to the Licensor shall be under the terms and conditions of this License, without any additional terms or conditions. Notwithstanding the above, nothing herein shall supersede or modify the terms of any separate license agreement you may have executed with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade names, trademarks, service marks, or product names of the Licensor, except as required for reasonable and customary use in describing the origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory, whether in tort (including negligence), contract, or otherwise, unless required by applicable law (such as deliberate and grossly negligent acts) or agreed to in writing, shall any Contributor be liable to You for damages, including any direct, indirect, special, incidental, or consequential damages of any character arising as a result of this License or out of the use or inability to use the Work (including but not limited to damages for loss of goodwill, work stoppage, computer failure or malfunction, or any and all other commercial damages or losses), even if such Contributor has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing the Work or Derivative Works thereof, You may choose to offer, and charge a fee for, acceptance of support, warranty, indemnity, or other liability obligations and/or rights consistent with this License. However, in accepting such obligations, You may act only on Your own behalf and on Your sole responsibility, not on behalf of any other Contributor, and only if You agree to indemnify, defend, and hold each Contributor harmless for any liability incurred by, or claims asserted against, such Contributor by reason of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification
+within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,7 +1,6 @@
 MIT License
 
-Copyright (c) oriolrius
-Copyright (c) 2026 YRoshcha (Protobuf + Schema Registry producer support)
+Copyright (c) Oriol Rius
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/MIGRATION_V6.md
+++ b/MIGRATION_V6.md
@@ -1,5 +1,17 @@
 # Migration Guide: v5.x to v6.0.0
 
+> **Note (this fork):** this guide documents the original `hm-kafka-*` →
+> `oriolrius-kafka-*` rename that [oriolrius](https://github.com/oriolrius/node-red-contrib-kafka)
+> made in the upstream project's v6.0.0, before this fork existed. Everything
+> below is historical background, kept for anyone still migrating from a
+> pre-v6 install. If you're installing this fork fresh, none of this applies
+> to you - just `npm install @yroshcha/node-red-contrib-kafka` and use the
+> `yroshcha-kafka-*` node types directly, per the main [README.md](README.md).
+> If you *are* migrating from an old `hm-kafka-*` install and want to land on
+> this fork, treat it as two hops: `hm-kafka-*` → `oriolrius-kafka-*` (as
+> described below) → `yroshcha-kafka-*` (find/replace once more, or just
+> re-drag fresh nodes from the palette).
+
 ## Breaking Changes
 
 Version 6.0.0 introduces a **breaking change** to resolve naming conflicts with other Kafka packages in the Node-RED ecosystem.
@@ -107,8 +119,9 @@ If you prefer to update your flows before deploying:
 
 If you encounter issues during migration:
 
-1. Check the [GitHub Issues](https://github.com/oriolrius/node-red-contrib-kafka/issues)
-2. Create a new issue with:
+1. Check the [GitHub Issues](https://github.com/oriolrius/node-red-contrib-kafka/issues) (for the original v5→v6 hm-/oriolrius- rename described above)
+2. For anything specific to this fork (`yroshcha-kafka-*` types, Protobuf producer support), use [this fork's issues](https://github.com/YRoshcha/node-red-contrib-kafka/issues) instead
+3. Create a new issue with:
    - Your Node-RED version
    - Package version (old and new)
    - Error messages or screenshots

--- a/NOTICE
+++ b/NOTICE
@@ -1,9 +1,19 @@
-This package is a fork of @oriolrius/node-red-contrib-kafka.
+This package is a fork of @oriolrius/node-red-contrib-kafka and contains work
+under multiple licenses.
 
 Original work:
 Oriol Rius
 https://github.com/oriolrius/node-red-contrib-kafka
 
+The original work and its unmodified portions remain available under the MIT
+License. See LICENSE-MIT.
+
 Fork modifications:
 Yehor Roshcha
 https://github.com/YRoshcha/node-red-contrib-kafka
+
+Yehor Roshcha's fork modifications, including the Protobuf and Confluent Schema
+Registry producer implementation and its documentation, are licensed under the
+Apache License, Version 2.0. See LICENSE-APACHE.
+
+Files containing both original and fork code are marked MIT AND Apache-2.0.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,9 @@
+This package is a fork of @oriolrius/node-red-contrib-kafka.
+
+Original work:
+Oriol Rius
+https://github.com/oriolrius/node-red-contrib-kafka
+
+Fork modifications:
+Yehor Roshcha
+https://github.com/YRoshcha/node-red-contrib-kafka

--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# @oriolrius/node-red-contrib-kafka
+# @yroshcha/node-red-contrib-kafka
+
+> This is a fork of [oriolrius/node-red-contrib-kafka](https://github.com/oriolrius/node-red-contrib-kafka),
+> adding Protobuf serialization (with Confluent Schema Registry wire-format
+> support) to the producer node, alongside the existing Avro mode. These
+> changes were originally submitted upstream as
+> [PR #4](https://github.com/oriolrius/node-red-contrib-kafka/pull/4); this
+> package is published separately since the PR has not received a maintainer
+> review. See [`docs/PROTOBUF_PRODUCER_GUIDE.md`](docs/PROTOBUF_PRODUCER_GUIDE.md)
+> for full usage details of the new capability.
+>
+> Node type names are prefixed `yroshcha-kafka-*` rather than
+> `oriolrius-kafka-*`, so this package can be installed safely alongside the
+> original `@oriolrius/node-red-contrib-kafka` in the same Node-RED instance
+> without type-registration conflicts.
 
 Kafka Consumer and Producer
 
@@ -16,15 +30,15 @@ This Node-RED Kafka client is based on the original `node-red-contrib-kafka` imp
 
 This node can be used to produce and consume messages to/from Kafka. It consists of five nodes:
 
-- **Kafka Broker** (oriolrius-kafka-broker) - Connection configuration
-- **Kafka Send** (oriolrius-kafka-producer) - Send messages to Kafka topics  
-- **Kafka Receive** (oriolrius-kafka-consumer) - Receive messages from Kafka topics
-- **Kafka Schema Send** (oriolrius-kafka-producer) - Send messages with Avro schema validation
-- **Kafka History Reader** (oriolrius-kafka-history-reader) - Retrieve historical messages by type
+- **Kafka Broker** (yroshcha-kafka-broker) - Connection configuration
+- **Kafka Send** (yroshcha-kafka-producer) - Send messages to Kafka topics  
+- **Kafka Receive** (yroshcha-kafka-consumer) - Receive messages from Kafka topics
+- **Kafka Schema Send** (yroshcha-kafka-producer) - Send messages with Avro schema validation
+- **Kafka History Reader** (yroshcha-kafka-history-reader) - Retrieve historical messages by type
 
 ### Schema Registry Support
 
-**NEW**: The `oriolrius-kafka-producer` node adds Avro schema validation support using Confluent Schema Registry. This node:
+**NEW**: The `yroshcha-kafka-producer` node adds Avro schema validation support using Confluent Schema Registry. This node:
 
 - Validates message payloads against registered Avro schemas
 - Supports both latest and specific schema versions for production stability
@@ -36,7 +50,7 @@ This node can be used to produce and consume messages to/from Kafka. It consists
 
 ### Kafka History Reader
 
-**NEW**: The `oriolrius-kafka-history-reader` node allows you to retrieve historical messages of specific types from Kafka topics. This is particularly useful for:
+**NEW**: The `yroshcha-kafka-history-reader` node allows you to retrieve historical messages of specific types from Kafka topics. This is particularly useful for:
 
 - Getting the last known values of specific message types before starting real-time consumption
 - Initializing your application state with historical data
@@ -62,7 +76,7 @@ These enhanced authentication mechanisms provide better security compared to the
 
 ## Installation
 ```
-npm install @oriolrius/node-red-contrib-kafka
+npm install @yroshcha/node-red-contrib-kafka
 ```
 
 ## Documentation
@@ -71,6 +85,7 @@ This project includes comprehensive documentation to help you get started and un
 
 ### Getting Started
 
+- **[Protobuf Producer Guide](docs/PROTOBUF_PRODUCER_GUIDE.md)** - Complete guide to Protobuf serialization (Schema Registry and raw modes) on the Kafka Send node
 - **[Schema Guide](docs/SCHEMA_GUIDE.md)** - Complete guide to using Avro schema validation and version management with the Schema Producer node
 - **[Kafka History Reader Guide](docs/KAFKA_HISTORY_READER_GUIDE.md)** - Complete guide to using the Kafka History Reader for retrieving historical messages
 - **[Migration Guide](docs/MIGRATION_GUIDE.md)** - Guide for migrating from legacy kafka-node based implementations

--- a/docs/IOT_INTEGRATION.md
+++ b/docs/IOT_INTEGRATION.md
@@ -113,7 +113,7 @@ Complete Node-RED flow example for IoT integration:
     },
     {
         "id": "ce8b5c02b1f4c17c",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "38455e3c08fa62ab",
         "name": "",
         "broker": "f7b89f9454780a93",
@@ -127,7 +127,7 @@ Complete Node-RED flow example for IoT integration:
     },
     {
         "id": "4b2b5ddfd4f03b36",
-        "type": "oriolrius-kafka-consumer",
+        "type": "yroshcha-kafka-consumer",
         "z": "38455e3c08fa62ab",
         "name": "",
         "broker": "f7b89f9454780a93",
@@ -182,7 +182,7 @@ Complete Node-RED flow example for IoT integration:
     },
     {
         "id": "f7b89f9454780a93",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "",
         "hosts": "147.13.93.122:19004",
         "usesasl": false,

--- a/docs/KAFKA_HISTORY_READER_GUIDE.md
+++ b/docs/KAFKA_HISTORY_READER_GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The `oriolrius-kafka-history-reader` node allows you to retrieve historical messages of specific types from a Kafka topic. This is particularly useful when you need to get the last known values of certain message types before starting real-time consumption.
+The `yroshcha-kafka-history-reader` node allows you to retrieve historical messages of specific types from a Kafka topic. This is particularly useful when you need to get the last known values of certain message types before starting real-time consumption.
 
 ## Key Features
 
@@ -212,8 +212,8 @@ return msg;
 
 This node is designed to work seamlessly with the existing Kafka nodes:
 
-- **oriolrius-kafka-broker**: Shared broker configuration
-- **oriolrius-kafka-consumer**: For real-time message consumption
-- **oriolrius-kafka-producer**: For sending responses based on historical data
+- **yroshcha-kafka-broker**: Shared broker configuration
+- **yroshcha-kafka-consumer**: For real-time message consumption
+- **yroshcha-kafka-producer**: For sending responses based on historical data
 
 The history reader complements rather than replaces the standard consumer, providing a complete solution for both historical and real-time Kafka message processing.

--- a/docs/KAFKA_HISTORY_READER_IMPLEMENTATION.md
+++ b/docs/KAFKA_HISTORY_READER_IMPLEMENTATION.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-Successfully created a new **Kafka History Reader** node (`oriolrius-kafka-history-reader`) that allows retrieving historical messages of specific types from Kafka topics before starting real-time consumption.
+Successfully created a new **Kafka History Reader** node (`yroshcha-kafka-history-reader`) that allows retrieving historical messages of specific types from Kafka topics before starting real-time consumption.
 
 ## Files Created/Modified
 

--- a/docs/NODE_NAMES_IMPROVEMENT.md
+++ b/docs/NODE_NAMES_IMPROVEMENT.md
@@ -10,7 +10,7 @@ This document outlines the improvements made to the Node-RED Kafka node names to
 
 | Node Type | Old Name/Label | New PaletteLabel | New Label | Improvement |
 |-----------|----------------|------------------|-----------|-------------|
-| **Broker** | "oriolrius-kafka-broker" | "Kafka Broker" | "Kafka Broker" | ✅ Clear, concise connection config |
+| **Broker** | "yroshcha-kafka-broker" | "Kafka Broker" | "Kafka Broker" | ✅ Clear, concise connection config |
 | **Producer** | "Data to Cloud" | "Kafka Send" | "Kafka Send" | ✅ Direct, action-oriented |
 | **Consumer** | "Data Subscription" | "Kafka Receive" | "Kafka Receive" | ✅ Clear receive action |
 | **Schema Producer** | "Publish with Schema" | "Kafka Schema Send" | "Kafka Schema Send" | ✅ Consistent with "Send" pattern |

--- a/docs/PROTOBUF_PRODUCER_GUIDE.md
+++ b/docs/PROTOBUF_PRODUCER_GUIDE.md
@@ -1,0 +1,196 @@
+# Kafka Send Node — Protobuf Serialization Guide
+
+## Overview
+
+Starting from **v6.2.0**, the Kafka Send node supports three serialization modes:
+
+| Mode | Config value | When to use |
+|------|-------------|-------------|
+| Avro + Schema Registry | `serializationType: "avro"` | Default; Confluent SR Avro encoding |
+| **Protobuf + Schema Registry** | `serializationType: "protobuf"`, `protobufMode: "registry"` | **Recommended.** Confluent wire format (magic byte + schema ID) |
+| Protobuf Raw | `serializationType: "protobuf"`, `protobufMode: "raw"` | No Schema Registry; pure protobufjs bytes |
+
+Node status badge shows the active mode: **`[avro]`**, **`[proto-sr]`**, or **`[proto-raw]`**.
+
+---
+
+## Node Configuration (UI fields)
+
+| Field | Description |
+|-------|-------------|
+| **Enable Schema Validation** | Must be **checked** to use any serialization |
+| **Serialization** | Choose `Avro` or `Protobuf` |
+| **Mode** *(Protobuf only)* | `Schema Registry` (recommended) or `Raw` |
+| **Registry URL** | Confluent Schema Registry URL, e.g. `http://localhost:8081` |
+| **Schema Subject** | Subject name in SR, e.g. `my-topic-value` |
+| **Schema Version** | `latest` or a specific version number |
+| **Use SR Authentication** | Enables username/password for SR |
+| **Auto-register schema** | Automatically register `.proto` in SR if not exists |
+| **Message Name** | Root message type name from your `.proto`, e.g. `MyEvent` |
+| **.proto Schema** | Full text of your `.proto` definition |
+
+---
+
+## What to put in `msg.payload`
+
+`msg.payload` must be a **plain JavaScript object** whose fields match the Protobuf message type defined in your `.proto` schema.
+
+### Example
+
+Given this `.proto` schema (configured in the node):
+
+```proto
+syntax = "proto3";
+
+message SensorReading {
+  string device_id  = 1;
+  double temperature = 2;
+  double humidity    = 3;
+  int64  timestamp   = 4;
+}
+```
+
+Send this `msg` from a Function node or Inject node:
+
+```javascript
+msg.payload = {
+    device_id:   "sensor-42",
+    temperature: 23.5,
+    humidity:    61.2,
+    timestamp:   Date.now()
+};
+return msg;
+```
+
+The Kafka Send node will:
+1. Validate the object against the `SensorReading` Protobuf type
+2. Encode it (Confluent wire format with schema ID header in SR mode, or raw bytes in raw mode)
+3. Publish the encoded bytes to the configured Kafka topic
+
+---
+
+## Optional message properties
+
+You can override the Kafka topic and message key per-message:
+
+```javascript
+msg.payload = { device_id: "sensor-42", temperature: 23.5, humidity: 61.2, timestamp: Date.now() };
+msg.topic   = "override-topic";   // optional: overrides the topic set in node config
+msg.key     = "sensor-42";        // optional: Kafka partition key
+return msg;
+```
+
+---
+
+## Nested messages
+
+Nested Protobuf messages are passed as nested JS objects:
+
+```proto
+syntax = "proto3";
+
+message Location {
+  double lat = 1;
+  double lon = 2;
+}
+
+message Vehicle {
+  string id       = 1;
+  Location pos    = 2;
+  float    speed  = 3;
+}
+```
+
+```javascript
+msg.payload = {
+    id:    "truck-007",
+    pos:   { lat: 50.45, lon: 30.52 },
+    speed: 87.3
+};
+return msg;
+```
+
+---
+
+## Repeated fields (arrays)
+
+```proto
+syntax = "proto3";
+
+message Batch {
+  string          source  = 1;
+  repeated double values  = 2;
+  repeated string tags    = 3;
+}
+```
+
+```javascript
+msg.payload = {
+    source: "collector-1",
+    values: [1.1, 2.2, 3.3],
+    tags:   ["prod", "europe"]
+};
+return msg;
+```
+
+---
+
+## Enum fields
+
+```proto
+syntax = "proto3";
+
+enum Status { UNKNOWN = 0; ACTIVE = 1; INACTIVE = 2; }
+
+message Device {
+  string id     = 1;
+  Status status = 2;
+}
+```
+
+Pass the **integer value** of the enum:
+
+```javascript
+msg.payload = {
+    id:     "device-01",
+    status: 1  // ACTIVE
+};
+return msg;
+```
+
+---
+
+## Output (what comes out of the node)
+
+After successful publish, the node passes `msg` downstream with `msg.payload` replaced by a result object:
+
+```javascript
+msg.payload = {
+    topic:         "my-topic",
+    messageCount:  42,
+    timestamp:     1716300000000,
+    serialization: "protobuf-registry"  // or "protobuf-raw" / "avro" / "none"
+};
+```
+
+---
+
+## Error handling
+
+| Situation | Behaviour |
+|-----------|-----------|
+| Object fields don't match the `.proto` definition | Node emits a warning, sets status to **Validation failed**, does **not** publish |
+| Schema Registry unreachable | Node logs an error, status turns red |
+| `msg.payload` is a JSON string | Node auto-parses it to an object before encoding |
+
+---
+
+## Mode comparison
+
+| | Protobuf + SR | Protobuf Raw |
+|---|---|---|
+| Confluent wire format header | ✅ magic byte + 4-byte schema ID | ❌ raw bytes only |
+| Compatible with ksqlDB / Confluent consumers | ✅ | ❌ |
+| Schema Registry required | ✅ | ❌ |
+| Auto-register schema | ✅ (optional) | — |
+| Node status badge | `[proto-sr]` | `[proto-raw]` |

--- a/docs/PROTOBUF_PRODUCER_GUIDE.md
+++ b/docs/PROTOBUF_PRODUCER_GUIDE.md
@@ -1,3 +1,8 @@
+<!--
+Copyright 2026 Yehor Roshcha
+SPDX-License-Identifier: Apache-2.0
+-->
+
 # Kafka Send Node — Protobuf Serialization Guide
 
 ## Overview

--- a/docs/SCHEMA_GUIDE.md
+++ b/docs/SCHEMA_GUIDE.md
@@ -16,7 +16,7 @@ The Kafka Schema Producer node provides:
 
 ### Required Settings
 
-1. **Kafka Broker**: Configure your existing oriolrius-kafka-broker node
+1. **Kafka Broker**: Configure your existing yroshcha-kafka-broker node
 2. **Schema Registry**: Set up Schema Registry connection (usually running on port 8081)
 3. **Topic**: The Kafka topic where messages will be published
 4. **Schema Subject**: The subject name in Schema Registry (e.g., "my-topic-value")
@@ -225,7 +225,7 @@ Request: subject="test-topic-value", version="3"
 ```json
 {
   "id": "schema-producer-basic",
-  "type": "oriolrius-kafka-producer",
+  "type": "yroshcha-kafka-producer",
   "name": "Basic Schema Producer",
   "broker": "broker1",
   "topic": "test-topic",
@@ -241,7 +241,7 @@ Request: subject="test-topic-value", version="3"
 ```json
 {
   "id": "schema-producer-prod",
-  "type": "oriolrius-kafka-producer",
+  "type": "yroshcha-kafka-producer",
   "name": "Producer (Schema v3)",
   "broker": "broker1",
   "topic": "test-topic",
@@ -319,7 +319,7 @@ Error output example:
     },
     {
         "id": "schema-producer1",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "name": "Publish with Schema",
         "broker": "broker1",
         "topic": "test-topic",

--- a/examples/basic-producer-consumer-example.json
+++ b/examples/basic-producer-consumer-example.json
@@ -33,7 +33,7 @@
     },
     {
         "id": "producer-node",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "example-flow",
         "name": "Send to Kafka",
         "broker": "broker-node",
@@ -71,7 +71,7 @@
     },
     {
         "id": "consumer-node",
-        "type": "oriolrius-kafka-consumer",
+        "type": "yroshcha-kafka-consumer",
         "z": "example-flow",
         "name": "Receive from Kafka",
         "broker": "broker-node",
@@ -128,7 +128,7 @@
     },
     {
         "id": "broker-node",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "Local Kafka",
         "hosts": "localhost:9092",
         "usesasl": false,

--- a/examples/compression-example.json
+++ b/examples/compression-example.json
@@ -33,7 +33,7 @@
     },
     {
         "id": "producer-gzip",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "compression-flow",
         "name": "GZIP Producer",
         "broker": "compression-broker",
@@ -96,7 +96,7 @@
     },
     {
         "id": "producer-snappy",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "compression-flow",
         "name": "Snappy Producer",
         "broker": "compression-broker",
@@ -159,7 +159,7 @@
     },
     {
         "id": "producer-lz4",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "compression-flow",
         "name": "LZ4 Producer",
         "broker": "compression-broker",
@@ -197,7 +197,7 @@
     },
     {
         "id": "consumer-compressed",
-        "type": "oriolrius-kafka-consumer",
+        "type": "yroshcha-kafka-consumer",
         "z": "compression-flow",
         "name": "Receive All (Auto-decompress)",
         "broker": "compression-broker",
@@ -254,7 +254,7 @@
     },
     {
         "id": "compression-broker",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "Local Kafka",
         "hosts": "localhost:9092",
         "usesasl": false,

--- a/examples/kafka-history-reader-complete-flow.json
+++ b/examples/kafka-history-reader-complete-flow.json
@@ -43,7 +43,7 @@
     },
     {
         "id": "history-reader",
-        "type": "oriolrius-kafka-history-reader",
+        "type": "yroshcha-kafka-history-reader",
         "z": "history-reader-example",
         "name": "Read Sensor History",
         "broker": "kafka-broker-config",
@@ -141,7 +141,7 @@
     },
     {
         "id": "kafka-consumer",
-        "type": "oriolrius-kafka-consumer",
+        "type": "yroshcha-kafka-consumer",
         "z": "history-reader-example",
         "name": "Real-time Consumer",
         "broker": "kafka-broker-config",
@@ -185,7 +185,7 @@
     },
     {
         "id": "kafka-broker-config",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "Local Kafka Broker",
         "hosts": "localhost:9092",
         "clientId": "nodered-client",

--- a/examples/kafka-history-reader-flow.json
+++ b/examples/kafka-history-reader-flow.json
@@ -43,7 +43,7 @@
     },
     {
         "id": "history-reader",
-        "type": "oriolrius-kafka-history-reader",
+        "type": "yroshcha-kafka-history-reader",
         "z": "history-reader-example",
         "name": "Read IoT History",
         "broker": "kafka-broker-config",
@@ -168,7 +168,7 @@
     },
     {
         "id": "realtime-consumer",
-        "type": "oriolrius-kafka-consumer",
+        "type": "yroshcha-kafka-consumer",
         "z": "history-reader-example",
         "name": "Real-time IoT Consumer",
         "broker": "kafka-broker-config",
@@ -229,7 +229,7 @@
     },
     {
         "id": "kafka-broker-config",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "Local Kafka",
         "hosts": "localhost:9092",
         "clientId": "node-red-client",

--- a/examples/schema-producer-example.json
+++ b/examples/schema-producer-example.json
@@ -33,7 +33,7 @@
     },
     {
         "id": "schema-producer",
-        "type": "oriolrius-kafka-producer",
+        "type": "yroshcha-kafka-producer",
         "z": "example-schema-flow",
         "name": "Kafka Schema Send",
         "broker": "kafka-broker",
@@ -109,7 +109,7 @@
     },
     {
         "id": "kafka-broker",
-        "type": "oriolrius-kafka-broker",
+        "type": "yroshcha-kafka-broker",
         "name": "Local Kafka",
         "hosts": "localhost:9092",
         "usesasl": false,

--- a/js/kafka-broker.html
+++ b/js/kafka-broker.html
@@ -110,6 +110,9 @@
 </script>
 
 <script type="text/javascript">
+(function() {
+"use strict";
+
 
 	// Data Types
 	const dataTypes = [
@@ -264,4 +267,6 @@
 			}
 		}
     });
+
+})();
 </script>

--- a/js/kafka-broker.html
+++ b/js/kafka-broker.html
@@ -1,11 +1,11 @@
-<script type="text/html" data-help-name="oriolrius-kafka-broker">
+<script type="text/html" data-help-name="yroshcha-kafka-broker">
     <p>Configure connection settings for Kafka cluster.</p>
     <p>This node defines the broker configuration that will be used by Kafka Send, Kafka Receive, and Kafka Schema Send nodes.</p>
     <p>"Hosts" can contain multiple brokers separated by commas, e.g.: localhost:9092,broker2:9092</p>
     <p>Supports SASL authentication (PLAIN, SCRAM-SHA-256, SCRAM-SHA-512) and TLS/SSL encryption.</p>
 </script>
 
-<script type="text/html" data-template-name="oriolrius-kafka-broker">
+<script type="text/html" data-template-name="yroshcha-kafka-broker">
 
     <div class="form-row">
         <label for="node-config-input-name"><i class="fa fa-tag"></i> Name</label>
@@ -121,7 +121,7 @@
 
 	const optionHtml = dataTypes.map(({value,label})=>`<option value="${value}">${label}</option>\n`);
 
-    RED.nodes.registerType('oriolrius-kafka-broker',{
+    RED.nodes.registerType('yroshcha-kafka-broker',{
         category: 'config',
         icon: "setting.png",
         defaults: {

--- a/js/kafka-broker.js
+++ b/js/kafka-broker.js
@@ -1,4 +1,3 @@
-
 module.exports = function (RED) {
     const fs = require('fs');
     const { Kafka } = require('kafkajs');
@@ -96,5 +95,5 @@ module.exports = function (RED) {
 
     }
 
-    RED.nodes.registerType("oriolrius-kafka-broker", KafkaBrokerNode);
+    RED.nodes.registerType("yroshcha-kafka-broker", KafkaBrokerNode);
 }

--- a/js/kafka-consumer.html
+++ b/js/kafka-consumer.html
@@ -1,11 +1,11 @@
-<script type="text/html" data-help-name="oriolrius-kafka-consumer">
+<script type="text/html" data-help-name="yroshcha-kafka-consumer">
     <p>Receive messages from a Kafka topic.</p>
     <p>This node subscribes to the specified Kafka topic and outputs received messages.</p>
     <p>Optionally decodes message payloads using registered Avro schemas from Confluent Schema Registry.</p>
     <p>Messages are output as they are received. Use the groupid property to control message distribution across multiple consumers.</p>
 </script>
 
-<script type="text/html" data-template-name="oriolrius-kafka-consumer">
+<script type="text/html" data-template-name="yroshcha-kafka-consumer">
 
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
@@ -108,13 +108,13 @@
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType('oriolrius-kafka-consumer', {
+    RED.nodes.registerType('yroshcha-kafka-consumer', {
         category: 'IOT',
         paletteLabel: "Kafka Receive",
         color: '#CE93D8',
         defaults: {
             name: { required: false },
-            broker: { type: "oriolrius-kafka-broker" },
+            broker: { type: "yroshcha-kafka-broker" },
             topic: { required: true },
             groupid: { required: false },
             fromOffset: { value: "latest" },

--- a/js/kafka-consumer.html
+++ b/js/kafka-consumer.html
@@ -108,6 +108,9 @@
 </script>
 
 <script type="text/javascript">
+(function() {
+"use strict";
+
     RED.nodes.registerType('yroshcha-kafka-consumer', {
         category: 'IOT',
         paletteLabel: "Kafka Receive",
@@ -165,4 +168,6 @@
             }
         }
     });
+
+})();
 </script>

--- a/js/kafka-consumer.js
+++ b/js/kafka-consumer.js
@@ -319,5 +319,5 @@ module.exports = function(RED) {
         node.init();
     }
     
-    RED.nodes.registerType("oriolrius-kafka-consumer", KafkaConsumerNode);
+    RED.nodes.registerType("yroshcha-kafka-consumer", KafkaConsumerNode);
 }

--- a/js/kafka-history-reader.html
+++ b/js/kafka-history-reader.html
@@ -159,6 +159,9 @@
 </script>
 
 <script type="text/javascript">
+(function() {
+"use strict";
+
     RED.nodes.registerType('yroshcha-kafka-history-reader', {
         category: 'IOT',
         paletteLabel: "kafka history",
@@ -221,4 +224,6 @@
             }
         }
     });
+
+})();
 </script>

--- a/js/kafka-history-reader.html
+++ b/js/kafka-history-reader.html
@@ -1,4 +1,4 @@
-<script type="text/html" data-help-name="oriolrius-kafka-history-reader">
+<script type="text/html" data-help-name="yroshcha-kafka-history-reader">
     <p>Retrieves historical messages from a Kafka topic starting from a specific offset.</p>
     
     <h3>Details</h3>
@@ -80,7 +80,7 @@
     debugging specific message ranges in your Kafka topics.</p>
 </script>
 
-<script type="text/html" data-template-name="oriolrius-kafka-history-reader">
+<script type="text/html" data-template-name="yroshcha-kafka-history-reader">
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name</label>
         <input type="text" id="node-input-name" placeholder="Kafka History Reader">
@@ -159,13 +159,13 @@
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType('oriolrius-kafka-history-reader', {
+    RED.nodes.registerType('yroshcha-kafka-history-reader', {
         category: 'IOT',
         paletteLabel: "kafka history",
         color: '#CE93D8',
         defaults: {
             name: { required: false },
-            broker: { type: "oriolrius-kafka-broker", required: true },
+            broker: { type: "yroshcha-kafka-broker", required: true },
             topic: { required: true },
             maxMessages: { value: 10, required: true, validate: function(v) { 
                 return v > 0 && v <= 1000; 

--- a/js/kafka-history-reader.js
+++ b/js/kafka-history-reader.js
@@ -307,5 +307,5 @@ module.exports = function(RED) {
         node.init();
     }
 
-    RED.nodes.registerType("oriolrius-kafka-history-reader", KafkaHistoryReaderNode);
+    RED.nodes.registerType("yroshcha-kafka-history-reader", KafkaHistoryReaderNode);
 };

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -1,9 +1,13 @@
 <script type="text/html" data-help-name="oriolrius-kafka-producer">
     <p>Send messages to a Kafka topic.</p>
     <p>This node publishes the incoming message payload to the specified Kafka topic.</p>
-    <p>Supports two serialization formats: <strong>Avro</strong> (via Confluent Schema Registry) and <strong>Protobuf</strong> (via protobufjs inline .proto definition).</p>
-    <p>Supports message compression, acknowledgment settings, and IoT cloud data formatting.</p>
-    <p>On successful send, the node status shows "Sent [avro]" or "Sent [protobuf]". On failure, shows "Error".</p>
+    <p>Supports three serialization modes:</p>
+    <ul>
+        <li><strong>Avro</strong> — Confluent Schema Registry with Avro encoding</li>
+        <li><strong>Protobuf + Schema Registry</strong> (priority) — registers .proto in Confluent SR, encodes with magic byte + schema ID (Confluent wire format)</li>
+        <li><strong>Protobuf raw</strong> — pure protobufjs encoding without Schema Registry</li>
+    </ul>
+    <p>Node status shows: <code>[avro]</code>, <code>[proto-sr]</code>, or <code>[proto-raw]</code>.</p>
 </script>
 
 <script type="text/html" data-template-name="oriolrius-kafka-producer">
@@ -50,7 +54,7 @@
 		<label for="node-input-useSchemaValidation" style="width: auto">Enable Schema Validation</label>
 	</div>
 
-    <!-- Schema Config Wrapper (shown when validation is enabled) -->
+    <!-- Schema Config Wrapper -->
     <div id="node-config-schema" style="display: none;">
 
         <!-- Serialization Type -->
@@ -58,11 +62,11 @@
             <label for="node-input-serializationType"><i class="fa fa-exchange"></i> Serialization</label>
             <select id="node-input-serializationType" style="width: 70%;">
                 <option value="avro">Avro (Confluent Schema Registry)</option>
-                <option value="protobuf">Protobuf (protobufjs)</option>
+                <option value="protobuf">Protobuf</option>
             </select>
         </div>
 
-        <!-- Avro configuration -->
+        <!-- ══ AVRO section ══════════════════════════════════════════════════════ -->
         <div id="node-config-avro">
             <div class="form-row">
                 <h4><i class="fa fa-cog"></i> Schema Registry Configuration</h4>
@@ -105,11 +109,56 @@
             </div>
         </div>
 
-        <!-- Protobuf configuration -->
+        <!-- ══ PROTOBUF section ══════════════════════════════════════════════════ -->
         <div id="node-config-protobuf" style="display: none;">
             <div class="form-row">
                 <h4><i class="fa fa-cog"></i> Protobuf Configuration</h4>
             </div>
+
+            <!-- Protobuf Mode selector -->
+            <div class="form-row">
+                <label for="node-input-protobufMode"><i class="fa fa-database"></i> Mode</label>
+                <select id="node-input-protobufMode" style="width: 70%;">
+                    <option value="registry">Schema Registry (Confluent SR + magic byte) — recommended</option>
+                    <option value="raw">Raw (protobufjs only, no Schema Registry)</option>
+                </select>
+            </div>
+
+            <!-- Schema Registry settings shown only in 'registry' mode -->
+            <div id="node-config-protobuf-sr">
+                <div class="form-row">
+                    <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL </label>
+                    <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
+                </div>
+                <div class="form-row">
+                    <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject </label>
+                    <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
+                </div>
+                <div class="form-row">
+                    <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version </label>
+                    <input type="text" id="node-input-schemaVersion" placeholder="latest">
+                </div>
+                <div class="form-row">
+                    <input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
+                    <label for="node-input-useRegistryAuth" style="width: auto">Use Schema Registry Authentication</label>
+                </div>
+                <div id="node-config-registry-auth-proto" style="display: none;">
+                    <div class="form-row">
+                        <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username </label>
+                        <input type="text" id="node-input-registryUsername" placeholder="username">
+                    </div>
+                    <div class="form-row">
+                        <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password </label>
+                        <input type="password" id="node-input-registryPassword" placeholder="password">
+                    </div>
+                </div>
+                <div class="form-row">
+                    <input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
+                    <label for="node-input-autoRegister" style="width: auto">Auto-register .proto schema in SR</label>
+                </div>
+            </div>
+
+            <!-- .proto definition and message name (shared for both modes) -->
             <div class="form-row">
                 <label for="node-input-protobufMessageName"><i class="fa fa-cube"></i> Message Name </label>
                 <input type="text" id="node-input-protobufMessageName" placeholder="Message" style="width: 70%;">
@@ -120,7 +169,7 @@
             </div>
         </div>
 
-        <!-- Validate Only (shared) -->
+        <!-- Validate Only (shared for all modes) -->
         <div class="form-row">
         	<input type="checkbox" id="node-input-validateOnly" style="display: inline-block; width: auto; vertical-align: top;">
         	<label for="node-input-validateOnly" style="width: auto">Validate schema only (don't publish)</label>
@@ -183,6 +232,8 @@
             attributes: { value: 0 },
             // Serialization Type (avro|protobuf), defaults to avro for backward compat
             serializationType: { value: 'avro' },
+            // Protobuf Mode: 'registry' (priority, Confluent SR) | 'raw' (protobufjs only)
+            protobufMode: { value: 'registry' },
             // Protobuf Configuration
             protobufSchema: { required: false, value: '' },
             protobufMessageName: { required: false, value: 'Message' },
@@ -229,9 +280,19 @@
                 if ($(this).val() === 'protobuf') {
                     $("#node-config-avro").hide();
                     $("#node-config-protobuf").show();
+                    $("#node-input-protobufMode").trigger('change');
                 } else {
                     $("#node-config-avro").show();
                     $("#node-config-protobuf").hide();
+                }
+            });
+
+            // Show/hide SR fields inside Protobuf section based on mode
+            $("#node-input-protobufMode").change(function() {
+                if ($(this).val() === 'registry') {
+                    $("#node-config-protobuf-sr").show();
+                } else {
+                    $("#node-config-protobuf-sr").hide();
                 }
             });
 
@@ -269,6 +330,12 @@
                 if (serType === 'protobuf') {
                     $("#node-config-avro").hide();
                     $("#node-config-protobuf").show();
+                    var protoMode = this.protobufMode || 'registry';
+                    if (protoMode === 'registry') {
+                        $("#node-config-protobuf-sr").show();
+                    } else {
+                        $("#node-config-protobuf-sr").hide();
+                    }
                 } else {
                     $("#node-config-avro").show();
                     $("#node-config-protobuf").hide();

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -197,6 +197,9 @@
 </script>
 
 <script type="text/javascript">
+(function() {
+"use strict";
+
     RED.nodes.registerType('yroshcha-kafka-producer', {
         category: 'IOT',
         paletteLabel: "Kafka Send",
@@ -399,4 +402,6 @@
             this.fields = fields;
         }
     });
+
+})();
 </script>

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -3,9 +3,9 @@
     <p>This node publishes the incoming message payload to the specified Kafka topic.</p>
     <p>Supports three serialization modes:</p>
     <ul>
-        <li><strong>Avro</strong> — Confluent Schema Registry with Avro encoding</li>
-        <li><strong>Protobuf + Schema Registry</strong> (priority) — registers .proto in Confluent SR, encodes with magic byte + schema ID (Confluent wire format)</li>
-        <li><strong>Protobuf raw</strong> — pure protobufjs encoding without Schema Registry</li>
+        <li><strong>Avro</strong> â Confluent Schema Registry with Avro encoding</li>
+        <li><strong>Protobuf + Schema Registry</strong> (priority) â registers .proto in Confluent SR, encodes with magic byte + schema ID (Confluent wire format)</li>
+        <li><strong>Protobuf raw</strong> â pure protobufjs encoding without Schema Registry</li>
     </ul>
     <p>Node status shows: <code>[avro]</code>, <code>[proto-sr]</code>, or <code>[proto-raw]</code>.</p>
 </script>
@@ -50,11 +50,10 @@
     <!-- Schema Validation Section -->
     <hr/>
     <div class="form-row">
-		<input type="checkbox" id="node-input-useSchemaValidation" style="display: inline-block; width: auto; vertical-align: top;">
-		<label for="node-input-useSchemaValidation" style="width: auto">Enable Schema Validation</label>
-	</div>
+        <input type="checkbox" id="node-input-useSchemaValidation" style="display: inline-block; width: auto; vertical-align: top;">
+        <label for="node-input-useSchemaValidation" style="width: auto">Enable Schema Validation</label>
+    </div>
 
-    <!-- Schema Config Wrapper -->
     <div id="node-config-schema" style="display: none;">
 
         <!-- Serialization Type -->
@@ -66,56 +65,8 @@
             </select>
         </div>
 
-        <!-- ══ AVRO section ══════════════════════════════════════════════════════ -->
-        <div id="node-config-avro">
-            <div class="form-row">
-                <h4><i class="fa fa-cog"></i> Schema Registry Configuration</h4>
-            </div>
-            <div class="form-row">
-                <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL </label>
-                <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
-            </div>
-            <div class="form-row">
-                <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject </label>
-                <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
-            </div>
-            <div class="form-row">
-                <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version </label>
-                <input type="text" id="node-input-schemaVersion" placeholder="latest">
-            </div>
-            <div class="form-row">
-                <input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
-                <label for="node-input-useRegistryAuth" style="width: auto">Use Schema Registry Authentication</label>
-            </div>
-            <div id="node-config-registry-auth" style="display: none;">
-                <div class="form-row">
-                    <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username </label>
-                    <input type="text" id="node-input-registryUsername" placeholder="username">
-                </div>
-                <div class="form-row">
-                    <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password </label>
-                    <input type="password" id="node-input-registryPassword" placeholder="password">
-                </div>
-            </div>
-            <div class="form-row">
-                <input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
-                <label for="node-input-autoRegister" style="width: auto">Auto-register schema</label>
-            </div>
-            <div id="node-config-auto-schema" style="display: none;">
-                <div class="form-row">
-                    <label for="node-input-autoSchema"><i class="fa fa-file-text-o"></i> Schema (JSON) </label>
-                    <textarea id="node-input-autoSchema" rows="6" style="width: 70%; font-family: monospace; font-size: 12px;"></textarea>
-                </div>
-            </div>
-        </div>
-
-        <!-- ══ PROTOBUF section ══════════════════════════════════════════════════ -->
-        <div id="node-config-protobuf" style="display: none;">
-            <div class="form-row">
-                <h4><i class="fa fa-cog"></i> Protobuf Configuration</h4>
-            </div>
-
-            <!-- Protobuf Mode selector -->
+        <!-- Protobuf mode selector — shown only when Protobuf selected -->
+        <div id="node-config-protobuf-mode" style="display: none;">
             <div class="form-row">
                 <label for="node-input-protobufMode"><i class="fa fa-database"></i> Mode</label>
                 <select id="node-input-protobufMode" style="width: 70%;">
@@ -123,56 +74,83 @@
                     <option value="raw">Raw (protobufjs only, no Schema Registry)</option>
                 </select>
             </div>
+        </div>
 
-            <!-- Schema Registry settings shown only in 'registry' mode -->
-            <div id="node-config-protobuf-sr">
+        <!-- Schema Registry fields — shared for Avro and Protobuf-SR -->
+        <div id="node-config-sr">
+            <div class="form-row">
+                <h4><i class="fa fa-cog"></i> Schema Registry Configuration</h4>
+            </div>
+            <div class="form-row">
+                <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL</label>
+                <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
+            </div>
+            <div class="form-row">
+                <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject</label>
+                <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
+            </div>
+            <div class="form-row">
+                <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version</label>
+                <input type="text" id="node-input-schemaVersion" placeholder="latest">
+            </div>
+
+            <!-- Auth -->
+            <div class="form-row">
+                <input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-input-useRegistryAuth" style="width: auto">Use Schema Registry Authentication</label>
+            </div>
+            <div id="node-config-registry-auth" style="display: none;">
                 <div class="form-row">
-                    <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL </label>
-                    <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
+                    <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username</label>
+                    <input type="text" id="node-input-registryUsername" placeholder="username">
                 </div>
                 <div class="form-row">
-                    <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject </label>
-                    <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
-                </div>
-                <div class="form-row">
-                    <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version </label>
-                    <input type="text" id="node-input-schemaVersion" placeholder="latest">
-                </div>
-                <div class="form-row">
-                    <input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
-                    <label for="node-input-useRegistryAuth" style="width: auto">Use Schema Registry Authentication</label>
-                </div>
-                <div id="node-config-registry-auth-proto" style="display: none;">
-                    <div class="form-row">
-                        <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username </label>
-                        <input type="text" id="node-input-registryUsername" placeholder="username">
-                    </div>
-                    <div class="form-row">
-                        <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password </label>
-                        <input type="password" id="node-input-registryPassword" placeholder="password">
-                    </div>
-                </div>
-                <div class="form-row">
-                    <input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
-                    <label for="node-input-autoRegister" style="width: auto">Auto-register .proto schema in SR</label>
+                    <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password</label>
+                    <input type="password" id="node-input-registryPassword" placeholder="password">
                 </div>
             </div>
 
-            <!-- .proto definition and message name (shared for both modes) -->
+            <!-- Auto-register -->
             <div class="form-row">
-                <label for="node-input-protobufMessageName"><i class="fa fa-cube"></i> Message Name </label>
+                <input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-input-autoRegister" style="width: auto">Auto-register schema</label>
+            </div>
+            <div id="node-config-auto-schema" style="display: none;">
+                <!-- Avro: JSON schema textarea -->
+                <div id="node-config-avro-schema">
+                    <div class="form-row">
+                        <label for="node-input-autoSchema"><i class="fa fa-file-text-o"></i> Avro Schema (JSON)</label>
+                        <textarea id="node-input-autoSchema" rows="6" style="width: 70%; font-family: monospace; font-size: 12px;"></textarea>
+                    </div>
+                </div>
+                <!-- Protobuf-SR: note that .proto below will be used -->
+                <div id="node-config-proto-schema-note" style="display: none;">
+                    <div class="form-row">
+                        <p><i class="fa fa-info-circle"></i> The <strong>.proto schema</strong> defined below will be registered in the Schema Registry.</p>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        <!-- Protobuf .proto fields — shown for both SR and raw Protobuf modes -->
+        <div id="node-config-proto-fields" style="display: none;">
+            <div class="form-row">
+                <h4><i class="fa fa-cog"></i> Protobuf Schema</h4>
+            </div>
+            <div class="form-row">
+                <label for="node-input-protobufMessageName"><i class="fa fa-cube"></i> Message Name</label>
                 <input type="text" id="node-input-protobufMessageName" placeholder="Message" style="width: 70%;">
             </div>
             <div class="form-row">
-                <label for="node-input-protobufSchema"><i class="fa fa-file-code-o"></i> .proto Schema </label>
+                <label for="node-input-protobufSchema"><i class="fa fa-file-code-o"></i> .proto Schema</label>
                 <textarea id="node-input-protobufSchema" rows="10" style="width: 70%; font-family: monospace; font-size: 12px;" placeholder='syntax = "proto3";&#10;&#10;message Message {&#10;  string id = 1;&#10;  string payload = 2;&#10;  int64 timestamp = 3;&#10;}'></textarea>
             </div>
         </div>
 
-        <!-- Validate Only (shared for all modes) -->
+        <!-- Validate Only (shared) -->
         <div class="form-row">
-        	<input type="checkbox" id="node-input-validateOnly" style="display: inline-block; width: auto; vertical-align: top;">
-        	<label for="node-input-validateOnly" style="width: auto">Validate schema only (don't publish)</label>
+            <input type="checkbox" id="node-input-validateOnly" style="display: inline-block; width: auto; vertical-align: top;">
+            <label for="node-input-validateOnly" style="width: auto">Validate schema only (don't publish)</label>
         </div>
     </div>
 
@@ -264,8 +242,30 @@
         },
         oneditprepare: function() {
             var node = this;
-            
-            // Show/hide schema validation fields
+
+            // ── helpers ──────────────────────────────────────────────────────
+            function updateSRVisibility() {
+                var serType   = $("#node-input-serializationType").val();
+                var protoMode = $("#node-input-protobufMode").val();
+                var needSR    = (serType === 'avro') || (serType === 'protobuf' && protoMode === 'registry');
+
+                if (needSR) {
+                    $("#node-config-sr").show();
+                } else {
+                    $("#node-config-sr").hide();
+                }
+
+                // Inside auto-register block: show Avro JSON or proto note
+                if (serType === 'avro') {
+                    $("#node-config-avro-schema").show();
+                    $("#node-config-proto-schema-note").hide();
+                } else {
+                    $("#node-config-avro-schema").hide();
+                    $("#node-config-proto-schema-note").show();
+                }
+            }
+
+            // ── Serialization type ────────────────────────────────────────────
             $("#node-input-useSchemaValidation").change(function() {
                 if ($(this).is(":checked")) {
                     $("#node-config-schema").show();
@@ -275,28 +275,25 @@
                 }
             });
 
-            // Show/hide Avro vs Protobuf config
             $("#node-input-serializationType").change(function() {
-                if ($(this).val() === 'protobuf') {
-                    $("#node-config-avro").hide();
-                    $("#node-config-protobuf").show();
+                var serType = $(this).val();
+                if (serType === 'protobuf') {
+                    $("#node-config-protobuf-mode").show();
+                    $("#node-config-proto-fields").show();
                     $("#node-input-protobufMode").trigger('change');
                 } else {
-                    $("#node-config-avro").show();
-                    $("#node-config-protobuf").hide();
+                    $("#node-config-protobuf-mode").hide();
+                    $("#node-config-proto-fields").hide();
+                    updateSRVisibility();
                 }
             });
 
-            // Show/hide SR fields inside Protobuf section based on mode
+            // ── Protobuf mode ─────────────────────────────────────────────────
             $("#node-input-protobufMode").change(function() {
-                if ($(this).val() === 'registry') {
-                    $("#node-config-protobuf-sr").show();
-                } else {
-                    $("#node-config-protobuf-sr").hide();
-                }
+                updateSRVisibility();
             });
 
-            // Show/hide registry auth fields
+            // ── Registry auth ─────────────────────────────────────────────────
             $("#node-input-useRegistryAuth").change(function() {
                 if ($(this).is(":checked")) {
                     $("#node-config-registry-auth").show();
@@ -305,7 +302,7 @@
                 }
             });
 
-            // Show/hide auto schema registration fields
+            // ── Auto-register schema ──────────────────────────────────────────
             $("#node-input-autoRegister").change(function() {
                 if ($(this).is(":checked")) {
                     $("#node-config-auto-schema").show();
@@ -314,51 +311,37 @@
                 }
             });
 
-            // Show/hide IoT configuration
-            $("#node-input-useiot").change(function() {
-                if ($(this).is(":checked")) {
-                    $("#node-config-iot").show();
-                } else {
-                    $("#node-config-iot").hide();
-                }
-            });
-
-            // Initialize visibility based on current values
+            // ── Restore visibility on edit open ───────────────────────────────
             if (this.useSchemaValidation) {
                 $("#node-config-schema").show();
-                var serType = this.serializationType || 'avro';
+                var serType   = this.serializationType || 'avro';
+                var protoMode = this.protobufMode || 'registry';
+
+                $("#node-input-serializationType").val(serType);
+                $("#node-input-protobufMode").val(protoMode);
+
                 if (serType === 'protobuf') {
-                    $("#node-config-avro").hide();
-                    $("#node-config-protobuf").show();
-                    var protoMode = this.protobufMode || 'registry';
-                    if (protoMode === 'registry') {
-                        $("#node-config-protobuf-sr").show();
-                    } else {
-                        $("#node-config-protobuf-sr").hide();
-                    }
-                } else {
-                    $("#node-config-avro").show();
-                    $("#node-config-protobuf").hide();
+                    $("#node-config-protobuf-mode").show();
+                    $("#node-config-proto-fields").show();
+                }
+                updateSRVisibility();
+
+                if (this.useRegistryAuth) {
+                    $("#node-config-registry-auth").show();
+                }
+                if (this.autoRegister) {
+                    $("#node-config-auto-schema").show();
                 }
             }
-            if (this.useRegistryAuth) {
-                $("#node-config-registry-auth").show();
-            }
-            if (this.autoRegister) {
-                $("#node-config-auto-schema").show();
-            }
+
+            // ── IoT fields ────────────────────────────────────────────────────
             if (this.useiot) {
                 $("#node-config-iot").show();
             }
 
-            // IoT Fields configuration
             function generateField(i, field) {
                 var container = $('<li/>', { style: "background: #fff; margin:0; padding:8px 0px; border-bottom: 1px solid #ccc;" });
                 var row = $('<div/>').appendTo(container);
-                var row2 = $('<div/>', { style: "padding-top: 5px;" }).appendTo(container);
-
-                $('<i style="color: #eee; cursor: move; margin-right: 3px;" class="fa fa-bars"></i>').appendTo(row);
-
                 var fieldName = $('<input/>', {
                     class: "node-input-field-name",
                     type: "text",
@@ -373,45 +356,33 @@
 
                 dataType.append('<option value="TEXT">TEXT</option>');
                 dataType.append('<option value="INT32">INT32</option>');
+                dataType.append('<option value="INT64">INT64</option>');
                 dataType.append('<option value="FLOAT">FLOAT</option>');
+                dataType.append('<option value="DOUBLE">DOUBLE</option>');
                 dataType.append('<option value="BOOLEAN">BOOLEAN</option>');
-                dataType.val(field.dataType);
 
-                var finalspan = $('<span/>', { style: "float: right; margin-right: 8px;" }).appendTo(row);
-                var deleteButton = $('<a/>', {
-                    href: "#",
-                    class: "editor-button editor-button-small",
-                    style: "margin-top: 7px; margin-left: 5px;"
-                }).appendTo(finalspan);
-                $('<i/>', { class: "fa fa-remove" }).appendTo(deleteButton);
+                dataType.val(field.dataType || "TEXT");
 
-                deleteButton.click(function() {
-                    container.fadeOut(300, function() {
-                        $(this).remove();
-                    });
-                });
+                $('<a/>', { href: "#", class: "editor-button editor-button-small", style: "margin-left: 5px;" })
+                    .html('<i class="fa fa-trash"></i>')
+                    .appendTo(row)
+                    .click(function() { container.remove(); });
 
-                $("#node-input-fields-container").append(container);
+                return container;
             }
 
-            // Add existing fields
-            for (var i = 0; i < this.fields.length; i++) {
-                generateField(i + 1, this.fields[i]);
-            }
-
-            // Add field button
-            $('<a href="#" class="editor-button" id="node-input-field-add" style="margin-top: 4px;"><i class="fa fa-plus"></i> Add Field</a>')
-                .appendTo($("#node-input-fields-container").parent())
-                .click(function() {
-                    generateField($("#node-input-fields-container").children().length + 1, { fieldName: "", dataType: "TEXT" });
-                });
-
-            // Make fields sortable
-            $("#node-input-fields-container").sortable({
-                axis: "y",
-                handle: ".fa-bars",
-                cursor: "move"
+            $("#node-input-add-field").click(function() {
+                var field = { fieldName: "", dataType: "TEXT" };
+                var container = generateField($("#node-input-fields-container").children().length, field);
+                container.appendTo($("#node-input-fields-container"));
+                container.find(".node-input-field-name").focus();
             });
+
+            var fields = node.fields || [];
+            for (var i = 0; i < fields.length; i++) {
+                var container = generateField(i, fields[i]);
+                container.appendTo($("#node-input-fields-container"));
+            }
         },
         oneditsave: function() {
             var fields = [];

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -1,9 +1,9 @@
 <script type="text/html" data-help-name="oriolrius-kafka-producer">
     <p>Send messages to a Kafka topic.</p>
     <p>This node publishes the incoming message payload to the specified Kafka topic.</p>
-    <p>Optionally validates message payloads against registered Avro schemas using Confluent Schema Registry.</p>
+    <p>Supports two serialization formats: <strong>Avro</strong> (via Confluent Schema Registry) and <strong>Protobuf</strong> (via protobufjs inline .proto definition).</p>
     <p>Supports message compression, acknowledgment settings, and IoT cloud data formatting.</p>
-    <p>On successful send, the node status shows "Sending". On failure, shows "Error".</p>
+    <p>On successful send, the node status shows "Sent [avro]" or "Sent [protobuf]". On failure, shows "Error".</p>
 </script>
 
 <script type="text/html" data-template-name="oriolrius-kafka-producer">
@@ -50,62 +50,84 @@
 		<label for="node-input-useSchemaValidation" style="width: auto">Enable Schema Validation</label>
 	</div>
 
-    <!-- Schema Registry Configuration (shown only when schema validation is enabled) -->
+    <!-- Schema Config Wrapper (shown when validation is enabled) -->
     <div id="node-config-schema" style="display: none;">
+
+        <!-- Serialization Type -->
         <div class="form-row">
-            <h4><i class="fa fa-cog"></i> Schema Registry Configuration</h4>
+            <label for="node-input-serializationType"><i class="fa fa-exchange"></i> Serialization</label>
+            <select id="node-input-serializationType" style="width: 70%;">
+                <option value="avro">Avro (Confluent Schema Registry)</option>
+                <option value="protobuf">Protobuf (protobufjs)</option>
+            </select>
         </div>
 
-        <div class="form-row">
-            <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL </label>
-            <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
-        </div>
-
-        <div class="form-row">
-            <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject </label>
-            <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
-        </div>
-
-        <div class="form-row">
-            <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version </label>
-            <input type="text" id="node-input-schemaVersion" placeholder="latest (or specific version like 1, 2, 3...)">
-        </div>
-
-        <div class="form-row">
-    		<input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
-    		<label for="node-input-useRegistryAuth" style="width: auto">Use Registry Authentication</label>
-    	</div>
-
-        <div id="node-config-registry-auth" class="form-row" style="display: none;">
+        <!-- Avro configuration -->
+        <div id="node-config-avro">
             <div class="form-row">
-                <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username </label>
-                <input type="text" id="node-input-registryUsername" placeholder="Username">
+                <h4><i class="fa fa-cog"></i> Schema Registry Configuration</h4>
             </div>
             <div class="form-row">
-                <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password </label>
-                <input type="password" id="node-input-registryPassword" placeholder="Password">
+                <label for="node-input-registryUrl"><i class="fa fa-globe"></i> Registry URL </label>
+                <input type="text" id="node-input-registryUrl" placeholder="http://localhost:8081">
             </div>
-        </div>
-
-        <div class="form-row">
-    		<input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
-    		<label for="node-input-autoRegister" style="width: auto">Auto-register schema if not found</label>
-    	</div>
-
-        <div id="node-config-auto-schema" class="form-row" style="display: none;">
             <div class="form-row">
-                <label for="node-input-autoSchema"><i class="fa fa-code"></i> Default Schema (JSON) </label>
-                <textarea id="node-input-autoSchema" rows="8" placeholder='{"type": "record", "name": "Message", "fields": [{"name": "id", "type": "string"}, {"name": "message", "type": "string"}]}'></textarea>
+                <label for="node-input-schemaSubject"><i class="fa fa-file-code-o"></i> Schema Subject </label>
+                <input type="text" id="node-input-schemaSubject" placeholder="my-topic-value">
+            </div>
+            <div class="form-row">
+                <label for="node-input-schemaVersion"><i class="fa fa-code-fork"></i> Schema Version </label>
+                <input type="text" id="node-input-schemaVersion" placeholder="latest">
+            </div>
+            <div class="form-row">
+                <input type="checkbox" id="node-input-useRegistryAuth" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-input-useRegistryAuth" style="width: auto">Use Schema Registry Authentication</label>
+            </div>
+            <div id="node-config-registry-auth" style="display: none;">
+                <div class="form-row">
+                    <label for="node-input-registryUsername"><i class="fa fa-user"></i> Username </label>
+                    <input type="text" id="node-input-registryUsername" placeholder="username">
+                </div>
+                <div class="form-row">
+                    <label for="node-input-registryPassword"><i class="fa fa-lock"></i> Password </label>
+                    <input type="password" id="node-input-registryPassword" placeholder="password">
+                </div>
+            </div>
+            <div class="form-row">
+                <input type="checkbox" id="node-input-autoRegister" style="display: inline-block; width: auto; vertical-align: top;">
+                <label for="node-input-autoRegister" style="width: auto">Auto-register schema</label>
+            </div>
+            <div id="node-config-auto-schema" style="display: none;">
+                <div class="form-row">
+                    <label for="node-input-autoSchema"><i class="fa fa-file-text-o"></i> Schema (JSON) </label>
+                    <textarea id="node-input-autoSchema" rows="6" style="width: 70%; font-family: monospace; font-size: 12px;"></textarea>
+                </div>
             </div>
         </div>
 
+        <!-- Protobuf configuration -->
+        <div id="node-config-protobuf" style="display: none;">
+            <div class="form-row">
+                <h4><i class="fa fa-cog"></i> Protobuf Configuration</h4>
+            </div>
+            <div class="form-row">
+                <label for="node-input-protobufMessageName"><i class="fa fa-cube"></i> Message Name </label>
+                <input type="text" id="node-input-protobufMessageName" placeholder="Message" style="width: 70%;">
+            </div>
+            <div class="form-row">
+                <label for="node-input-protobufSchema"><i class="fa fa-file-code-o"></i> .proto Schema </label>
+                <textarea id="node-input-protobufSchema" rows="10" style="width: 70%; font-family: monospace; font-size: 12px;" placeholder='syntax = "proto3";&#10;&#10;message Message {&#10;  string id = 1;&#10;  string payload = 2;&#10;  int64 timestamp = 3;&#10;}'></textarea>
+            </div>
+        </div>
+
+        <!-- Validate Only (shared) -->
         <div class="form-row">
-    		<input type="checkbox" id="node-input-validateOnly" style="display: inline-block; width: auto; vertical-align: top;">
-    		<label for="node-input-validateOnly" style="width: auto">Validate schema only (don't publish)</label>
-    	</div>
+        	<input type="checkbox" id="node-input-validateOnly" style="display: inline-block; width: auto; vertical-align: top;">
+        	<label for="node-input-validateOnly" style="width: auto">Validate schema only (don't publish)</label>
+        </div>
     </div>
 
-    <!-- IoT Configuration Section -->
+<!-- IoT Configuration Section -->
     <hr/>
     <div class="form-row">
 		<input type="checkbox" id="node-input-useiot" style="display: inline-block; width: auto; vertical-align: top;">
@@ -159,6 +181,11 @@
             requireAcks: { value: 1, required: true },
             ackTimeoutMs: { value: 100, required: true },
             attributes: { value: 0 },
+            // Serialization Type (avro|protobuf), defaults to avro for backward compat
+            serializationType: { value: 'avro' },
+            // Protobuf Configuration
+            protobufSchema: { required: false, value: '' },
+            protobufMessageName: { required: false, value: 'Message' },
             // Schema Validation
             useSchemaValidation: { value: false },
             // Schema Registry Configuration
@@ -191,8 +218,20 @@
             $("#node-input-useSchemaValidation").change(function() {
                 if ($(this).is(":checked")) {
                     $("#node-config-schema").show();
+                    $("#node-input-serializationType").trigger('change');
                 } else {
                     $("#node-config-schema").hide();
+                }
+            });
+
+            // Show/hide Avro vs Protobuf config
+            $("#node-input-serializationType").change(function() {
+                if ($(this).val() === 'protobuf') {
+                    $("#node-config-avro").hide();
+                    $("#node-config-protobuf").show();
+                } else {
+                    $("#node-config-avro").show();
+                    $("#node-config-protobuf").hide();
                 }
             });
 
@@ -226,6 +265,14 @@
             // Initialize visibility based on current values
             if (this.useSchemaValidation) {
                 $("#node-config-schema").show();
+                var serType = this.serializationType || 'avro';
+                if (serType === 'protobuf') {
+                    $("#node-config-avro").hide();
+                    $("#node-config-protobuf").show();
+                } else {
+                    $("#node-config-avro").show();
+                    $("#node-config-protobuf").hide();
+                }
             }
             if (this.useRegistryAuth) {
                 $("#node-config-registry-auth").show();

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -1,4 +1,4 @@
-<script type="text/html" data-help-name="oriolrius-kafka-producer">
+<script type="text/html" data-help-name="yroshcha-kafka-producer">
     <p>Send messages to a Kafka topic.</p>
     <p>This node publishes the incoming message payload to the specified Kafka topic.</p>
     <p>Supports three serialization modes:</p>
@@ -10,7 +10,7 @@
     <p>Node status shows: <code>[avro]</code>, <code>[proto-sr]</code>, or <code>[proto-raw]</code>.</p>
 </script>
 
-<script type="text/html" data-template-name="oriolrius-kafka-producer">
+<script type="text/html" data-template-name="yroshcha-kafka-producer">
 
     <div class="form-row">
         <label for="node-input-name"><i class="fa fa-tag"></i> Name </label>
@@ -197,13 +197,13 @@
 </script>
 
 <script type="text/javascript">
-    RED.nodes.registerType('oriolrius-kafka-producer', {
+    RED.nodes.registerType('yroshcha-kafka-producer', {
         category: 'IOT',
         paletteLabel: "Kafka Send",
         color: '#CE93D8',
         defaults: {
             name: { required: false },
-            broker: { type: "oriolrius-kafka-broker" },
+            broker: { type: "yroshcha-kafka-broker" },
             topic: { required: true },
             requireAcks: { value: 1, required: true },
             ackTimeoutMs: { value: 100, required: true },

--- a/js/kafka-producer.html
+++ b/js/kafka-producer.html
@@ -1,3 +1,11 @@
+<!--
+  Copyright 2025 Oriol Rius
+  Copyright 2026 Yehor Roshcha
+
+  This file contains original MIT-licensed work and Apache-2.0-licensed fork
+  modifications. See LICENSE, LICENSE-MIT, LICENSE-APACHE, and NOTICE.
+  SPDX-License-Identifier: MIT AND Apache-2.0
+-->
 <script type="text/html" data-help-name="yroshcha-kafka-producer">
     <p>Send messages to a Kafka topic.</p>
     <p>This node publishes the incoming message payload to the specified Kafka topic.</p>

--- a/js/kafka-producer.js
+++ b/js/kafka-producer.js
@@ -506,5 +506,5 @@ module.exports = function (RED) {
         node.init();
     }
 
-    RED.nodes.registerType('oriolrius-kafka-producer', KafkaProducerNode);
+    RED.nodes.registerType('yroshcha-kafka-producer', KafkaProducerNode);
 };

--- a/js/kafka-producer.js
+++ b/js/kafka-producer.js
@@ -112,7 +112,7 @@ module.exports = function (RED) {
                             return;
                         }
                     } else {
-                        node.debug(`[Kafka Protobuf Raw] No Schema Registry – raw encoding`);
+                        node.debug(`[Kafka Protobuf Raw] No Schema Registry â raw encoding`);
                         node.status({ fill: 'yellow', shape: 'ring', text: 'Protobuf raw mode' });
                     }
 
@@ -182,7 +182,7 @@ module.exports = function (RED) {
             }
         };
 
-        // ── Avro: get / auto-register schema from Confluent SR ───────────────────
+        // ââ Avro: get / auto-register schema from Confluent SR âââââââââââââââââââ
         node.getOrRegisterAvroSchema = async function () {
             const version = config.schemaVersion && config.schemaVersion.trim() !== ''
                 ? config.schemaVersion.trim() : 'latest';
@@ -223,7 +223,7 @@ module.exports = function (RED) {
             return schemaId;
         };
 
-        // ── Protobuf + Schema Registry: register .proto and encode ───────────────
+        // ââ Protobuf + Schema Registry: register .proto and encode âââââââââââââââ
         //    Registers the .proto definition in Confluent SR (type PROTOBUF),
         //    then uses schemaRegistry.encode() which prepends the Confluent wire
         //    format header (magic byte 0x00 + 4-byte schema ID).
@@ -265,7 +265,7 @@ module.exports = function (RED) {
             return schemaId;
         };
 
-        // ── Protobuf raw: pure protobufjs encoding, no Schema Registry ────────────
+        // ââ Protobuf raw: pure protobufjs encoding, no Schema Registry ââââââââââââ
         node.encodeProtobufRaw = function (messageData) {
             if (!node.protobufType) {
                 throw new Error('Protobuf type not loaded. Check your .proto schema definition.');
@@ -276,7 +276,7 @@ module.exports = function (RED) {
             return Buffer.from(node.protobufType.encode(protoMsg).finish());
         };
 
-        // ── Input handler ─────────────────────────────────────────────────────────
+        // ââ Input handler âââââââââââââââââââââââââââââââââââââââââââââââââââââââââ
         node.on('input', async function (msg) {
             const serializationType = config.serializationType || 'avro';
             const protobufMode      = config.protobufMode || 'registry';
@@ -326,7 +326,7 @@ module.exports = function (RED) {
                     if (serializationType === 'protobuf') {
 
                         if (protobufMode === 'registry') {
-                            // ── Protobuf + Schema Registry (priority) ─────────────
+                            // ââ Protobuf + Schema Registry (priority) âââââââââââââ
                             node.debug(`[Kafka Protobuf SR] Encoding via Schema Registry`);
                             node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (proto-sr)' });
 
@@ -351,10 +351,22 @@ module.exports = function (RED) {
 
                             // schemaRegistry.encode prepends magic byte + schema ID header
                             serializedValue = await node.schemaRegistry.encode(schemaId, messageData);
+
+                            // Confluent Protobuf wire format requires a message index byte (0x00 for
+                            // the first/only message type) at position 5, right after the 5-byte header
+                            // (magic byte 0x00 + 4-byte schema ID). Some SR client versions omit it.
+                            if (serializedValue.length > 5 && serializedValue.readUInt8(5) !== 0) {
+                                const patched = Buffer.alloc(serializedValue.length + 1);
+                                serializedValue.copy(patched, 0, 0, 5);   // copy 5-byte header
+                                patched.writeUInt8(0, 5);                  // insert message index 0x00
+                                serializedValue.copy(patched, 6, 5);       // copy protobuf payload
+                                serializedValue = patched;
+                                node.debug('[Kafka Protobuf SR] Inserted missing Confluent message index byte');
+                            }
                             node.debug(`[Kafka Protobuf SR] Encoded with schema ID: ${schemaId}`);
 
                         } else {
-                            // ── Protobuf raw (no Schema Registry) ─────────────────
+                            // ââ Protobuf raw (no Schema Registry) âââââââââââââââââ
                             node.debug(`[Kafka Protobuf Raw] Encoding with protobufjs`);
                             node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (proto-raw)' });
 
@@ -380,7 +392,7 @@ module.exports = function (RED) {
                         }
 
                     } else {
-                        // ── Avro + Schema Registry ─────────────────────────────────
+                        // ââ Avro + Schema Registry âââââââââââââââââââââââââââââââââ
                         node.debug(`[Kafka Avro SR] Encoding via Schema Registry`);
                         node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (avro)' });
 

--- a/js/kafka-producer.js
+++ b/js/kafka-producer.js
@@ -3,21 +3,15 @@ module.exports = function (RED) {
     const { CompressionTypes, CompressionCodecs } = require('kafkajs');
     const { getNameTypes, getMsgValues } = require('./utils');
 
-    // Register compression codecs
-    // KafkaJS expects factory functions that return codec instances
     try {
         const SnappyCodec = require('kafkajs-snappy');
         CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
-    } catch (error) {
-        // Snappy codec not available
-    }
+    } catch (error) { /* Snappy codec not available */ }
 
     try {
         const LZ4Codec = require('kafkajs-lz4');
         CompressionCodecs[CompressionTypes.LZ4] = () => new LZ4Codec();
-    } catch (error) {
-        // LZ4 codec not available
-    }
+    } catch (error) { /* LZ4 codec not available */ }
 
     function getIotOptions(config) {
         var options = new Object();
@@ -40,64 +34,91 @@ module.exports = function (RED) {
         node.cachedSchemaVersion = null;
         node.lastMessageTime = null;
         node.messageCount = 0;
-        // Protobuf support
         node.protobufType = null;
         node.protobufRoot = null;
 
         let iotOptions = {};
 
         node.init = function () {
+            // serializationType: 'avro' | 'protobuf'
+            // protobufMode:      'registry' (priority, uses Confluent SR) | 'raw' (protobufjs only)
             const serializationType = config.serializationType || 'avro';
-            const nodeType = config.useSchemaValidation
-                ? (serializationType === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
+            const protobufMode      = config.protobufMode || 'registry';
+
+            const nodeLabel = config.useSchemaValidation
+                ? (serializationType === 'protobuf'
+                    ? (protobufMode === 'raw' ? 'Protobuf Raw Producer' : 'Protobuf SR Producer')
+                    : 'Schema Producer')
                 : 'Producer';
+
             const versionInfo = config.useSchemaValidation && config.schemaVersion && config.schemaVersion.trim() !== ''
                 ? ` (schema version: ${config.schemaVersion.trim()})` : '';
-            node.debug(`[Kafka ${nodeType}] Initializing for topic: ${config.topic}${versionInfo}`);
-            node.status({ fill: "yellow", shape: "ring", text: "Initializing..." });
+            node.debug(`[Kafka ${nodeLabel}] Initializing for topic: ${config.topic}${versionInfo}`);
+            node.status({ fill: 'yellow', shape: 'ring', text: 'Initializing...' });
 
             let broker = RED.nodes.getNode(config.broker);
             if (!broker) {
-                node.error(`[Kafka ${nodeType}] No broker configuration found`);
-                node.status({ fill: "red", shape: "ring", text: "No broker config" });
+                node.error(`[Kafka ${nodeLabel}] No broker configuration found`);
+                node.status({ fill: 'red', shape: 'ring', text: 'No broker config' });
                 return;
             }
 
             if (broker && broker.getIotConfig) {
                 const brokerIotConfig = broker.getIotConfig();
-                if (brokerIotConfig.useiot) {
-                    iotOptions = brokerIotConfig;
-                    node.debug(`[Kafka Producer] Using IoT configuration from broker`);
-                } else {
-                    iotOptions = getIotOptions(config);
-                    node.debug(`[Kafka Producer] Using IoT configuration from producer`);
-                }
+                iotOptions = brokerIotConfig.useiot ? brokerIotConfig : getIotOptions(config);
             } else {
                 iotOptions = getIotOptions(config);
-                node.debug(`[Kafka Producer] Using producer IoT configuration`);
             }
 
             if (config.useSchemaValidation) {
+
                 if (serializationType === 'protobuf') {
-                    node.status({ fill: "yellow", shape: "ring", text: "Loading Protobuf schema..." });
+                    // Always parse the .proto definition (needed for validation + raw encoding)
+                    node.status({ fill: 'yellow', shape: 'ring', text: 'Loading Protobuf schema...' });
                     try {
                         const protobuf = require('protobufjs');
                         if (!config.protobufSchema || config.protobufSchema.trim() === '') {
-                            throw new Error('Protobuf schema definition is required');
+                            throw new Error('Protobuf schema (.proto) definition is required');
                         }
                         const messageName = config.protobufMessageName || 'Message';
                         const root = protobuf.parse(config.protobufSchema, { keepCase: true }).root;
                         node.protobufType = root.lookupType(messageName);
                         node.protobufRoot = root;
-                        node.debug(`[Kafka Protobuf Producer] Loaded type "${messageName}"`);
-                        node.status({ fill: "yellow", shape: "ring", text: "Protobuf schema loaded" });
+                        node.debug(`[Kafka Protobuf] Loaded .proto type "${messageName}"`);
                     } catch (error) {
-                        node.error(`[Kafka Protobuf Producer] Failed to load Protobuf schema: ${error.message}`);
-                        node.status({ fill: "red", shape: "ring", text: `Proto error: ${error.message.substring(0, 15)}...` });
+                        node.error(`[Kafka Protobuf] Failed to parse .proto schema: ${error.message}`);
+                        node.status({ fill: 'red', shape: 'ring', text: `Proto parse error` });
                         return;
                     }
+
+                    if (protobufMode === 'registry') {
+                        // Protobuf + Schema Registry: register .proto in Confluent SR
+                        node.status({ fill: 'yellow', shape: 'ring', text: 'Connecting to SR (Protobuf)...' });
+                        try {
+                            const registryConfig = {
+                                host: config.registryUrl,
+                                clientId: 'node-red-protobuf-producer',
+                                retry: { retries: 3, factor: 2, multiplier: 1000, maxRetryTimeInSecs: 60 }
+                            };
+                            if (config.useRegistryAuth && config.registryUsername && config.registryPassword) {
+                                registryConfig.auth = { username: config.registryUsername, password: config.registryPassword };
+                            }
+                            node.schemaRegistry = new SchemaRegistry(registryConfig);
+                            node.debug(`[Kafka Protobuf SR] Registry client created: ${config.registryUrl}`);
+                            node.status({ fill: 'yellow', shape: 'ring', text: 'Protobuf SR connected' });
+                        } catch (error) {
+                            node.error(`[Kafka Protobuf SR] Failed to create SR client: ${error.message}`);
+                            node.status({ fill: 'red', shape: 'ring', text: 'SR failed' });
+                            return;
+                        }
+                    } else {
+                        node.debug(`[Kafka Protobuf Raw] No Schema Registry – raw encoding`);
+                        node.status({ fill: 'yellow', shape: 'ring', text: 'Protobuf raw mode' });
+                    }
+
                 } else {
-                    node.status({ fill: "yellow", shape: "ring", text: "Connecting to Schema Registry..." });
+                    // Avro + Schema Registry
+                    node.status({ fill: 'yellow', shape: 'ring', text: 'Connecting to SR (Avro)...' });
                     try {
                         const registryConfig = {
                             host: config.registryUrl,
@@ -105,18 +126,15 @@ module.exports = function (RED) {
                             retry: { retries: 3, factor: 2, multiplier: 1000, maxRetryTimeInSecs: 60 }
                         };
                         if (config.useRegistryAuth && config.registryUsername && config.registryPassword) {
-                            registryConfig.auth = {
-                                username: config.registryUsername,
-                                password: config.registryPassword,
-                            };
-                            node.debug(`[Kafka Schema Producer] Registry auth for user: ${config.registryUsername}`);
+                            registryConfig.auth = { username: config.registryUsername, password: config.registryPassword };
+                            node.debug(`[Kafka Avro SR] Auth configured for user: ${config.registryUsername}`);
                         }
                         node.schemaRegistry = new SchemaRegistry(registryConfig);
-                        node.debug(`[Kafka Schema Producer] Schema Registry client created for: ${config.registryUrl}`);
-                        node.status({ fill: "yellow", shape: "ring", text: "Registry connected" });
+                        node.debug(`[Kafka Avro SR] Registry client created: ${config.registryUrl}`);
+                        node.status({ fill: 'yellow', shape: 'ring', text: 'Avro SR connected' });
                     } catch (error) {
-                        node.error(`[Kafka Schema Producer] Failed to create Schema Registry client: ${error.message}`);
-                        node.status({ fill: "red", shape: "ring", text: `Registry failed: ${error.message.substring(0, 10)}...` });
+                        node.error(`[Kafka Avro SR] Failed to create SR client: ${error.message}`);
+                        node.status({ fill: 'red', shape: 'ring', text: 'Registry failed' });
                         return;
                     }
                 }
@@ -124,7 +142,7 @@ module.exports = function (RED) {
                 node.debug(`[Kafka Producer] Schema validation disabled`);
             }
 
-            node.status({ fill: "yellow", shape: "ring", text: "Connecting to Kafka..." });
+            node.status({ fill: 'yellow', shape: 'ring', text: 'Connecting to Kafka...' });
             try {
                 const kafka = broker.getKafka();
                 const producer = kafka.producer({
@@ -134,182 +152,249 @@ module.exports = function (RED) {
                 });
 
                 producer.connect().then(() => {
-                    node.debug(`[Kafka Schema Producer] Producer connected`);
+                    node.debug(`[Kafka Producer] Connected`);
                     node.ready = true;
                     node.lastMessageTime = new Date().getTime();
                     node.messageCount = 0;
-                    node.status({ fill: "green", shape: "ring", text: "Ready" });
+                    node.status({ fill: 'green', shape: 'ring', text: 'Ready' });
 
                     producer.on('producer.connect', () => {
-                        node.debug(`[Kafka Schema Producer] Producer connected to Kafka`);
-                        node.status({ fill: "green", shape: "ring", text: "Connected" });
+                        node.status({ fill: 'green', shape: 'ring', text: 'Connected' });
                     });
                     producer.on('producer.disconnect', () => {
-                        node.debug(`[Kafka Schema Producer] Producer disconnected from Kafka`);
-                        node.status({ fill: "red", shape: "ring", text: "Disconnected" });
+                        node.status({ fill: 'red', shape: 'ring', text: 'Disconnected' });
                         node.ready = false;
                         node.lastMessageTime = null;
                         node.messageCount = 0;
                     });
-
                     node.producer = producer;
                 }).catch(error => {
-                    node.error(`[Kafka Schema Producer] Failed to connect: ${error.message}`, error);
-                    node.status({ fill: "red", shape: "ring", text: `Connect failed: ${error.message.substring(0, 15)}...` });
+                    node.error(`[Kafka Producer] Failed to connect: ${error.message}`, error);
+                    node.status({ fill: 'red', shape: 'ring', text: `Connect failed` });
                     node.ready = false;
                     node.lastMessageTime = null;
                 });
             } catch (error) {
-                node.error(`[Kafka Schema Producer] Failed to get Kafka: ${error.message}`, error);
-                node.status({ fill: "red", shape: "ring", text: `Kafka failed: ${error.message.substring(0, 10)}...` });
+                node.error(`[Kafka Producer] Failed to get Kafka instance: ${error.message}`, error);
+                node.status({ fill: 'red', shape: 'ring', text: 'Kafka failed' });
                 node.ready = false;
                 node.lastMessageTime = null;
             }
         };
 
-        node.getOrRegisterSchema = async function () {
-            try {
-                const version = config.schemaVersion && config.schemaVersion.trim() !== '' ? config.schemaVersion.trim() : 'latest';
-                if (node.cachedSchemaId && node.cachedSchemaVersion === version) {
-                    node.debug(`[Kafka Schema Producer] Using cached schema ID: ${node.cachedSchemaId}`);
-                    node.status({ fill: "blue", shape: "ring", text: `Using cached schema v${version}` });
-                    return node.cachedSchemaId;
-                }
+        // ── Avro: get / auto-register schema from Confluent SR ───────────────────
+        node.getOrRegisterAvroSchema = async function () {
+            const version = config.schemaVersion && config.schemaVersion.trim() !== ''
+                ? config.schemaVersion.trim() : 'latest';
 
-                node.debug(`[Kafka Schema Producer] Fetching schema for version: ${version}`);
-                node.status({ fill: "blue", shape: "ring", text: "Getting schema..." });
-
-                try {
-                    let schemaId;
-                    if (version === 'latest') {
-                        if (config.autoRegister && config.autoSchema) {
-                            let schemaObject;
-                            try {
-                                schemaObject = JSON.parse(config.autoSchema);
-                            } catch (parseError) {
-                                throw new Error(`Invalid schema JSON: ${parseError.message}`);
-                            }
-                            const registeredSchema = await node.schemaRegistry.register({
-                                type: SchemaType.AVRO,
-                                schema: JSON.stringify(schemaObject)
-                            }, { subject: config.schemaSubject });
-                            schemaId = registeredSchema.id;
-                            node.debug(`[Kafka Schema Producer] Schema auto-registered ID: ${schemaId}`);
-                        } else {
-                            schemaId = await node.schemaRegistry.getLatestSchemaId(config.schemaSubject);
-                            node.debug(`[Kafka Schema Producer] Latest schema ID: ${schemaId}`);
-                        }
-                    } else {
-                        schemaId = await node.schemaRegistry.getSchemaId(config.schemaSubject, parseInt(version));
-                        node.debug(`[Kafka Schema Producer] Schema ID for v${version}: ${schemaId}`);
-                    }
-                    node.cachedSchemaId = schemaId;
-                    node.cachedSchemaVersion = version;
-                    node.status({ fill: "blue", shape: "ring", text: `Schema v${version} cached` });
-                    return schemaId;
-                } catch (fetchError) {
-                    node.error(`[Kafka Schema Producer] Failed to get/register schema: ${fetchError.message}`);
-                    throw fetchError;
-                }
-            } catch (error) {
-                node.error(`[Kafka Schema Producer] Schema operation failed: ${error.message}`);
-                throw error;
+            if (node.cachedSchemaId && node.cachedSchemaVersion === version) {
+                node.debug(`[Kafka Avro SR] Using cached schema ID: ${node.cachedSchemaId}`);
+                node.status({ fill: 'blue', shape: 'ring', text: `Cached schema v${version}` });
+                return node.cachedSchemaId;
             }
+
+            node.debug(`[Kafka Avro SR] Fetching schema, version: ${version}`);
+            node.status({ fill: 'blue', shape: 'ring', text: 'Getting Avro schema...' });
+
+            let schemaId;
+            if (version === 'latest') {
+                if (config.autoRegister && config.autoSchema) {
+                    let schemaObject;
+                    try { schemaObject = JSON.parse(config.autoSchema); }
+                    catch (e) { throw new Error(`Invalid Avro schema JSON: ${e.message}`); }
+                    const registered = await node.schemaRegistry.register(
+                        { type: SchemaType.AVRO, schema: JSON.stringify(schemaObject) },
+                        { subject: config.schemaSubject }
+                    );
+                    schemaId = registered.id;
+                    node.debug(`[Kafka Avro SR] Schema registered/found, ID: ${schemaId}`);
+                } else {
+                    schemaId = await node.schemaRegistry.getLatestSchemaId(config.schemaSubject);
+                    node.debug(`[Kafka Avro SR] Latest ID for "${config.schemaSubject}": ${schemaId}`);
+                }
+            } else {
+                schemaId = await node.schemaRegistry.getSchemaId(config.schemaSubject, parseInt(version));
+                node.debug(`[Kafka Avro SR] Schema ID for v${version}: ${schemaId}`);
+            }
+
+            node.cachedSchemaId = schemaId;
+            node.cachedSchemaVersion = version;
+            node.status({ fill: 'blue', shape: 'ring', text: `Avro schema v${version} cached` });
+            return schemaId;
         };
 
-        node.encodeProtobuf = function (messageData) {
+        // ── Protobuf + Schema Registry: register .proto and encode ───────────────
+        //    Registers the .proto definition in Confluent SR (type PROTOBUF),
+        //    then uses schemaRegistry.encode() which prepends the Confluent wire
+        //    format header (magic byte 0x00 + 4-byte schema ID).
+        node.getOrRegisterProtobufSchema = async function () {
+            const version = config.schemaVersion && config.schemaVersion.trim() !== ''
+                ? config.schemaVersion.trim() : 'latest';
+
+            if (node.cachedSchemaId && node.cachedSchemaVersion === version) {
+                node.debug(`[Kafka Protobuf SR] Using cached schema ID: ${node.cachedSchemaId}`);
+                node.status({ fill: 'blue', shape: 'ring', text: `Cached proto schema v${version}` });
+                return node.cachedSchemaId;
+            }
+
+            node.debug(`[Kafka Protobuf SR] Fetching/registering .proto schema, version: ${version}`);
+            node.status({ fill: 'blue', shape: 'ring', text: 'Getting Protobuf schema...' });
+
+            let schemaId;
+            if (version === 'latest') {
+                if (config.autoRegister && config.protobufSchema) {
+                    // Register (or idempotently get existing) .proto schema in SR
+                    const registered = await node.schemaRegistry.register(
+                        { type: SchemaType.PROTOBUF, schema: config.protobufSchema },
+                        { subject: config.schemaSubject }
+                    );
+                    schemaId = registered.id;
+                    node.debug(`[Kafka Protobuf SR] .proto registered/found in SR, ID: ${schemaId}`);
+                } else {
+                    schemaId = await node.schemaRegistry.getLatestSchemaId(config.schemaSubject);
+                    node.debug(`[Kafka Protobuf SR] Latest ID for "${config.schemaSubject}": ${schemaId}`);
+                }
+            } else {
+                schemaId = await node.schemaRegistry.getSchemaId(config.schemaSubject, parseInt(version));
+                node.debug(`[Kafka Protobuf SR] Schema ID for v${version}: ${schemaId}`);
+            }
+
+            node.cachedSchemaId = schemaId;
+            node.cachedSchemaVersion = version;
+            node.status({ fill: 'blue', shape: 'ring', text: `Proto schema v${version} cached` });
+            return schemaId;
+        };
+
+        // ── Protobuf raw: pure protobufjs encoding, no Schema Registry ────────────
+        node.encodeProtobufRaw = function (messageData) {
             if (!node.protobufType) {
                 throw new Error('Protobuf type not loaded. Check your .proto schema definition.');
             }
             const errMsg = node.protobufType.verify(messageData);
-            if (errMsg) {
-                throw new Error(`Protobuf validation error: ${errMsg}`);
-            }
-            const protoMessage = node.protobufType.create(messageData);
-            return Buffer.from(node.protobufType.encode(protoMessage).finish());
+            if (errMsg) throw new Error(`Protobuf validation error: ${errMsg}`);
+            const protoMsg = node.protobufType.create(messageData);
+            return Buffer.from(node.protobufType.encode(protoMsg).finish());
         };
 
+        // ── Input handler ─────────────────────────────────────────────────────────
         node.on('input', async function (msg) {
             const serializationType = config.serializationType || 'avro';
-            const nodeType = config.useSchemaValidation
-                ? (serializationType === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
+            const protobufMode      = config.protobufMode || 'registry';
+
+            const nodeLabel = config.useSchemaValidation
+                ? (serializationType === 'protobuf'
+                    ? (protobufMode === 'raw' ? 'Protobuf Raw Producer' : 'Protobuf SR Producer')
+                    : 'Schema Producer')
                 : 'Producer';
-            node.debug(`[Kafka ${nodeType}] Received input message`);
+
+            node.debug(`[Kafka ${nodeLabel}] Received input message`);
 
             if (!node.ready) {
-                node.warn(`[Kafka ${nodeType}] Producer not ready, skipping message`);
+                node.warn(`[Kafka ${nodeLabel}] Producer not ready, skipping message`);
                 return;
             }
 
             try {
                 let messageData = msg.payload;
-
                 if (typeof messageData === 'string') {
                     try { messageData = JSON.parse(messageData); } catch (e) { /* keep as string */ }
                 }
 
+                // IoT formatting
                 if (iotOptions && iotOptions.useiot) {
                     if (typeof messageData === 'string') {
-                        try {
-                            messageData = JSON.parse(messageData);
-                        } catch (parseError) {
-                            node.error(`[Kafka ${nodeType}] Failed to parse payload as JSON: ${parseError.message}`);
-                            node.status({ fill: "red", shape: "ring", text: "Parse error" });
+                        try { messageData = JSON.parse(messageData); }
+                        catch (parseError) {
+                            node.error(`[Kafka ${nodeLabel}] Failed to parse payload as JSON: ${parseError.message}`);
+                            node.status({ fill: 'red', shape: 'ring', text: 'Parse error' });
                             return;
                         }
                     }
                     const nameTypes = getNameTypes(iotOptions.fields);
                     const msgValues = getMsgValues(messageData, iotOptions.fields);
                     messageData = {
-                        mc: iotOptions.model,
-                        dc: iotOptions.device,
-                        type: iotOptions.iotType,
-                        nameTypes: nameTypes,
-                        ts: [new Date().getTime()],
-                        values: [msgValues]
+                        mc: iotOptions.model, dc: iotOptions.device,
+                        type: iotOptions.iotType, nameTypes,
+                        ts: [new Date().getTime()], values: [msgValues]
                     };
-                    node.debug(`[Kafka Producer] IoT formatted message:`, messageData);
                 }
 
                 let serializedValue;
 
                 if (config.useSchemaValidation) {
-                    if (serializationType === 'protobuf') {
-                        node.debug(`[Kafka Protobuf Producer] Encoding with Protobuf`);
-                        node.status({ fill: "blue", shape: "dot", text: "Encoding (protobuf)" });
 
-                        if (config.validateOnly) {
-                            const errMsg = node.protobufType ? node.protobufType.verify(messageData) : 'Protobuf type not loaded';
-                            if (errMsg) {
-                                node.warn(`[Kafka Protobuf Producer] Validation failed: ${errMsg}`);
-                                node.status({ fill: "yellow", shape: "ring", text: "Validation failed" });
-                                msg.payload = { validated: false, error: errMsg };
+                    if (serializationType === 'protobuf') {
+
+                        if (protobufMode === 'registry') {
+                            // ── Protobuf + Schema Registry (priority) ─────────────
+                            node.debug(`[Kafka Protobuf SR] Encoding via Schema Registry`);
+                            node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (proto-sr)' });
+
+                            const schemaId = await node.getOrRegisterProtobufSchema();
+
+                            if (config.validateOnly) {
+                                const errMsg = node.protobufType
+                                    ? node.protobufType.verify(messageData)
+                                    : 'Protobuf type not loaded';
+                                if (errMsg) {
+                                    node.warn(`[Kafka Protobuf SR] Validation failed: ${errMsg}`);
+                                    node.status({ fill: 'yellow', shape: 'ring', text: 'Validation failed' });
+                                    msg.payload = { validated: false, error: errMsg };
+                                    node.send(msg);
+                                    return;
+                                }
+                                node.status({ fill: 'green', shape: 'ring', text: 'Validated (not sent)' });
+                                msg.payload = { validated: true, schemaId };
                                 node.send(msg);
                                 return;
                             }
-                            node.status({ fill: "green", shape: "ring", text: "Validated (not sent)" });
-                            msg.payload = { validated: true };
-                            node.send(msg);
-                            return;
+
+                            // schemaRegistry.encode prepends magic byte + schema ID header
+                            serializedValue = await node.schemaRegistry.encode(schemaId, messageData);
+                            node.debug(`[Kafka Protobuf SR] Encoded with schema ID: ${schemaId}`);
+
+                        } else {
+                            // ── Protobuf raw (no Schema Registry) ─────────────────
+                            node.debug(`[Kafka Protobuf Raw] Encoding with protobufjs`);
+                            node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (proto-raw)' });
+
+                            if (config.validateOnly) {
+                                const errMsg = node.protobufType
+                                    ? node.protobufType.verify(messageData)
+                                    : 'Protobuf type not loaded';
+                                if (errMsg) {
+                                    node.warn(`[Kafka Protobuf Raw] Validation failed: ${errMsg}`);
+                                    node.status({ fill: 'yellow', shape: 'ring', text: 'Validation failed' });
+                                    msg.payload = { validated: false, error: errMsg };
+                                    node.send(msg);
+                                    return;
+                                }
+                                node.status({ fill: 'green', shape: 'ring', text: 'Validated (not sent)' });
+                                msg.payload = { validated: true };
+                                node.send(msg);
+                                return;
+                            }
+
+                            serializedValue = node.encodeProtobufRaw(messageData);
+                            node.debug(`[Kafka Protobuf Raw] Encoded to ${serializedValue.length} bytes`);
                         }
 
-                        serializedValue = node.encodeProtobuf(messageData);
-                        node.debug(`[Kafka Protobuf Producer] Encoded to ${serializedValue.length} bytes`);
                     } else {
-                        node.debug(`[Kafka Schema Producer] Encoding with Avro`);
-                        node.status({ fill: "blue", shape: "dot", text: "Encoding message" });
+                        // ── Avro + Schema Registry ─────────────────────────────────
+                        node.debug(`[Kafka Avro SR] Encoding via Schema Registry`);
+                        node.status({ fill: 'blue', shape: 'dot', text: 'Encoding (avro)' });
 
-                        const schemaId = await node.getOrRegisterSchema();
+                        const schemaId = await node.getOrRegisterAvroSchema();
 
                         if (config.validateOnly) {
                             try {
                                 await node.schemaRegistry.encode(schemaId, messageData);
-                                node.status({ fill: "green", shape: "ring", text: "Validated (not sent)" });
+                                node.status({ fill: 'green', shape: 'ring', text: 'Validated (not sent)' });
                                 msg.payload = { validated: true, schemaId };
                                 node.send(msg);
                             } catch (validationError) {
-                                node.warn(`[Kafka Schema Producer] Validation failed: ${validationError.message}`);
-                                node.status({ fill: "yellow", shape: "ring", text: "Validation failed" });
+                                node.warn(`[Kafka Avro SR] Validation failed: ${validationError.message}`);
+                                node.status({ fill: 'yellow', shape: 'ring', text: 'Validation failed' });
                                 msg.payload = { validated: false, error: validationError.message };
                                 node.send(msg);
                             }
@@ -317,8 +402,9 @@ module.exports = function (RED) {
                         }
 
                         serializedValue = await node.schemaRegistry.encode(schemaId, messageData);
-                        node.debug(`[Kafka Schema Producer] Encoded with schema ID: ${schemaId}`);
+                        node.debug(`[Kafka Avro SR] Encoded with schema ID: ${schemaId}`);
                     }
+
                 } else {
                     serializedValue = typeof messageData === 'string' ? messageData : JSON.stringify(messageData);
                 }
@@ -331,55 +417,63 @@ module.exports = function (RED) {
                 } else if (config.messageKey && config.messageKey.trim() !== '') {
                     kafkaMessage.key = config.messageKey.trim();
                 }
-
                 if (msg.headers && typeof msg.headers === 'object') {
                     kafkaMessage.headers = msg.headers;
                 }
 
-                node.debug(`[Kafka ${nodeType}] Sending message to topic: ${topic}`);
-                node.status({ fill: "blue", shape: "dot", text: "Sending..." });
+                node.debug(`[Kafka ${nodeLabel}] Sending to topic: ${topic}`);
+                node.status({ fill: 'blue', shape: 'dot', text: 'Sending...' });
 
-                const compressionType = config.compressionType !== undefined ? Number(config.compressionType) : CompressionTypes.None;
+                const compressionType = config.compressionType !== undefined
+                    ? Number(config.compressionType) : CompressionTypes.None;
 
-                await node.producer.send({
-                    topic: topic,
-                    compression: compressionType,
-                    messages: [kafkaMessage]
-                });
+                await node.producer.send({ topic, compression: compressionType, messages: [kafkaMessage] });
 
                 node.messageCount++;
                 node.lastMessageTime = new Date().getTime();
 
-                const serTag = config.useSchemaValidation ? (serializationType === 'protobuf' ? ' [protobuf]' : ' [avro]') : '';
-                node.status({ fill: "green", shape: "dot", text: `Sent${serTag} #${node.messageCount}` });
-                node.debug(`[Kafka ${nodeType}] Sent OK. Count: ${node.messageCount}`);
+                let serTag = '';
+                if (config.useSchemaValidation) {
+                    serTag = serializationType === 'protobuf'
+                        ? (protobufMode === 'raw' ? ' [proto-raw]' : ' [proto-sr]')
+                        : ' [avro]';
+                }
+                node.status({ fill: 'green', shape: 'dot', text: `Sent${serTag} #${node.messageCount}` });
 
                 msg.payload = {
                     topic,
                     messageCount: node.messageCount,
                     timestamp: node.lastMessageTime,
-                    serialization: config.useSchemaValidation ? (serializationType === 'protobuf' ? 'protobuf' : 'avro') : 'none'
+                    serialization: config.useSchemaValidation
+                        ? (serializationType === 'protobuf'
+                            ? (protobufMode === 'raw' ? 'protobuf-raw' : 'protobuf-registry')
+                            : 'avro')
+                        : 'none'
                 };
                 node.send(msg);
 
             } catch (error) {
-                const nt = config.useSchemaValidation
-                    ? ((config.serializationType || 'avro') === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
-                    : 'Producer';
-                node.error(`[Kafka ${nt}] Error: ${error.message}`, error);
-                node.status({ fill: "red", shape: "ring", text: `Error: ${error.message.substring(0, 15)}...` });
+                node.error(`[Kafka Producer] Error: ${error.message}`, error);
+                node.status({ fill: 'red', shape: 'ring', text: `Error: ${error.message.substring(0, 15)}...` });
                 node.lastMessageTime = null;
             }
         });
 
         node.checkLastMessageTime = function () {
             if (node.lastMessageTime) {
+                const serializationType = config.serializationType || 'avro';
+                const protobufMode      = config.protobufMode || 'registry';
+                let serTag = '';
+                if (config.useSchemaValidation) {
+                    serTag = serializationType === 'protobuf'
+                        ? (protobufMode === 'raw' ? ' [proto-raw]' : ' [proto-sr]')
+                        : ' [avro]';
+                }
                 const timeSince = new Date().getTime() - node.lastMessageTime;
                 const minutes = Math.floor(timeSince / 60000);
                 const seconds = Math.floor((timeSince % 60000) / 1000);
-                const serializationType = config.serializationType || 'avro';
-                const serTag = config.useSchemaValidation ? ` [${serializationType}]` : '';
-                node.status({ fill: "green", shape: "ring", text: `Ready${serTag} | Last: ${minutes}m ${seconds}s | Count: ${node.messageCount}` });
+                node.status({ fill: 'green', shape: 'ring',
+                    text: `Ready${serTag} | Last: ${minutes}m ${seconds}s | Count: ${node.messageCount}` });
             }
         };
 
@@ -389,13 +483,9 @@ module.exports = function (RED) {
             node.protobufType = null;
             node.protobufRoot = null;
             if (node.producer) {
-                node.producer.disconnect().then(() => {
-                    node.debug(`[Kafka Producer] Producer disconnected`);
-                    done();
-                }).catch(error => {
-                    node.error(`[Kafka Producer] Error disconnecting: ${error.message}`);
-                    done();
-                });
+                node.producer.disconnect()
+                    .then(() => { node.debug('[Kafka Producer] Disconnected'); done(); })
+                    .catch(error => { node.error(`[Kafka Producer] Error: ${error.message}`); done(); });
             } else {
                 done();
             }

--- a/js/kafka-producer.js
+++ b/js/kafka-producer.js
@@ -1,5 +1,5 @@
 module.exports = function (RED) {
-    const { SchemaRegistry } = require('@kafkajs/confluent-schema-registry');
+    const { SchemaRegistry, SchemaType } = require('@kafkajs/confluent-schema-registry');
     const { CompressionTypes, CompressionCodecs } = require('kafkajs');
     const { getNameTypes, getMsgValues } = require('./utils');
 
@@ -7,21 +7,20 @@ module.exports = function (RED) {
     // KafkaJS expects factory functions that return codec instances
     try {
         const SnappyCodec = require('kafkajs-snappy');
-        CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;  // Factory function
+        CompressionCodecs[CompressionTypes.Snappy] = SnappyCodec;
     } catch (error) {
         // Snappy codec not available
     }
 
     try {
         const LZ4Codec = require('kafkajs-lz4');
-        CompressionCodecs[CompressionTypes.LZ4] = () => new LZ4Codec();  // Factory function wrapper
+        CompressionCodecs[CompressionTypes.LZ4] = () => new LZ4Codec();
     } catch (error) {
         // LZ4 codec not available
     }
 
     function getIotOptions(config) {
         var options = new Object();
-
         if (config.useiot) {
             options = new Object();
             options.model = config.model;
@@ -29,7 +28,6 @@ module.exports = function (RED) {
             options.iotType = config.iotType;
             options.fields = config.fields;
         }
-
         return options;
     }
 
@@ -42,24 +40,29 @@ module.exports = function (RED) {
         node.cachedSchemaVersion = null;
         node.lastMessageTime = null;
         node.messageCount = 0;
+        // Protobuf support
+        node.protobufType = null;
+        node.protobufRoot = null;
 
         let iotOptions = {};
 
         node.init = function () {
-            const nodeType = config.useSchemaValidation ? 'Schema Producer' : 'Producer';
-            const versionInfo = config.useSchemaValidation && config.schemaVersion && config.schemaVersion.trim() !== '' 
+            const serializationType = config.serializationType || 'avro';
+            const nodeType = config.useSchemaValidation
+                ? (serializationType === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
+                : 'Producer';
+            const versionInfo = config.useSchemaValidation && config.schemaVersion && config.schemaVersion.trim() !== ''
                 ? ` (schema version: ${config.schemaVersion.trim()})` : '';
-            node.debug(`[Kafka ${nodeType}] Initializing ${nodeType.toLowerCase()} for topic: ${config.topic}${versionInfo}`);
+            node.debug(`[Kafka ${nodeType}] Initializing for topic: ${config.topic}${versionInfo}`);
             node.status({ fill: "yellow", shape: "ring", text: "Initializing..." });
-            
+
             let broker = RED.nodes.getNode(config.broker);
             if (!broker) {
-                node.error(`[Kafka Schema Producer] No broker configuration found`);
+                node.error(`[Kafka ${nodeType}] No broker configuration found`);
                 node.status({ fill: "red", shape: "ring", text: "No broker config" });
                 return;
             }
 
-            // Get IoT configuration from broker if available, otherwise use producer config
             if (broker && broker.getIotConfig) {
                 const brokerIotConfig = broker.getIotConfig();
                 if (brokerIotConfig.useiot) {
@@ -73,49 +76,57 @@ module.exports = function (RED) {
                 iotOptions = getIotOptions(config);
                 node.debug(`[Kafka Producer] Using producer IoT configuration`);
             }
-            
-            // Initialize Schema Registry only if schema validation is enabled
+
             if (config.useSchemaValidation) {
-                node.status({ fill: "yellow", shape: "ring", text: "Connecting to Schema Registry..." });
-            try {
-                const registryConfig = {
-                    host: config.registryUrl,
-                    clientId: 'node-red-schema-producer',
-                    retry: {
-                        retries: 3,
-                        factor: 2,
-                        multiplier: 1000,
-                        maxRetryTimeInSecs: 60
+                if (serializationType === 'protobuf') {
+                    node.status({ fill: "yellow", shape: "ring", text: "Loading Protobuf schema..." });
+                    try {
+                        const protobuf = require('protobufjs');
+                        if (!config.protobufSchema || config.protobufSchema.trim() === '') {
+                            throw new Error('Protobuf schema definition is required');
+                        }
+                        const messageName = config.protobufMessageName || 'Message';
+                        const root = protobuf.parse(config.protobufSchema, { keepCase: true }).root;
+                        node.protobufType = root.lookupType(messageName);
+                        node.protobufRoot = root;
+                        node.debug(`[Kafka Protobuf Producer] Loaded type "${messageName}"`);
+                        node.status({ fill: "yellow", shape: "ring", text: "Protobuf schema loaded" });
+                    } catch (error) {
+                        node.error(`[Kafka Protobuf Producer] Failed to load Protobuf schema: ${error.message}`);
+                        node.status({ fill: "red", shape: "ring", text: `Proto error: ${error.message.substring(0, 15)}...` });
+                        return;
                     }
-                };
-
-                // Add authentication if configured
-                if (config.useRegistryAuth && config.registryUsername && config.registryPassword) {
-                    registryConfig.auth = {
-                        username: config.registryUsername,
-                        password: config.registryPassword,
-                    };
-                    node.debug(`[Kafka Schema Producer] Schema Registry auth configured for user: ${config.registryUsername}`);
-                }
-
-                node.schemaRegistry = new SchemaRegistry(registryConfig);
-                node.debug(`[Kafka Schema Producer] Schema Registry client created for: ${config.registryUrl}`);
-                node.status({ fill: "yellow", shape: "ring", text: "Registry connected" });
-                } catch (error) {
-                    node.error(`[Kafka Schema Producer] Failed to create Schema Registry client: ${error.message}`);
-                    node.status({ fill: "red", shape: "ring", text: `Registry failed: ${error.message.substring(0, 10)}...` });
-                    return;
+                } else {
+                    node.status({ fill: "yellow", shape: "ring", text: "Connecting to Schema Registry..." });
+                    try {
+                        const registryConfig = {
+                            host: config.registryUrl,
+                            clientId: 'node-red-schema-producer',
+                            retry: { retries: 3, factor: 2, multiplier: 1000, maxRetryTimeInSecs: 60 }
+                        };
+                        if (config.useRegistryAuth && config.registryUsername && config.registryPassword) {
+                            registryConfig.auth = {
+                                username: config.registryUsername,
+                                password: config.registryPassword,
+                            };
+                            node.debug(`[Kafka Schema Producer] Registry auth for user: ${config.registryUsername}`);
+                        }
+                        node.schemaRegistry = new SchemaRegistry(registryConfig);
+                        node.debug(`[Kafka Schema Producer] Schema Registry client created for: ${config.registryUrl}`);
+                        node.status({ fill: "yellow", shape: "ring", text: "Registry connected" });
+                    } catch (error) {
+                        node.error(`[Kafka Schema Producer] Failed to create Schema Registry client: ${error.message}`);
+                        node.status({ fill: "red", shape: "ring", text: `Registry failed: ${error.message.substring(0, 10)}...` });
+                        return;
+                    }
                 }
             } else {
-                node.debug(`[Kafka Producer] Schema validation disabled, skipping Schema Registry setup`);
+                node.debug(`[Kafka Producer] Schema validation disabled`);
             }
 
-            // Get Kafka client from broker
             node.status({ fill: "yellow", shape: "ring", text: "Connecting to Kafka..." });
             try {
                 const kafka = broker.getKafka();
-                node.debug(`[Kafka Schema Producer] Kafka instance obtained successfully`);
-                
                 const producer = kafka.producer({
                     maxInFlightRequests: 1,
                     idempotent: config.requireAcks === 1,
@@ -123,18 +134,16 @@ module.exports = function (RED) {
                 });
 
                 producer.connect().then(() => {
-                    node.debug(`[Kafka Schema Producer] Producer ready and connected to Kafka broker`);
+                    node.debug(`[Kafka Schema Producer] Producer connected`);
                     node.ready = true;
                     node.lastMessageTime = new Date().getTime();
                     node.messageCount = 0;
                     node.status({ fill: "green", shape: "ring", text: "Ready" });
-                    
-                    // Set up producer event handlers
+
                     producer.on('producer.connect', () => {
                         node.debug(`[Kafka Schema Producer] Producer connected to Kafka`);
                         node.status({ fill: "green", shape: "ring", text: "Connected" });
                     });
-
                     producer.on('producer.disconnect', () => {
                         node.debug(`[Kafka Schema Producer] Producer disconnected from Kafka`);
                         node.status({ fill: "red", shape: "ring", text: "Disconnected" });
@@ -143,96 +152,64 @@ module.exports = function (RED) {
                         node.messageCount = 0;
                     });
 
-                    // Store producer reference
                     node.producer = producer;
-
                 }).catch(error => {
-                    node.error(`[Kafka Schema Producer] Failed to connect producer: ${error.message}`, error);
+                    node.error(`[Kafka Schema Producer] Failed to connect: ${error.message}`, error);
                     node.status({ fill: "red", shape: "ring", text: `Connect failed: ${error.message.substring(0, 15)}...` });
                     node.ready = false;
                     node.lastMessageTime = null;
                 });
-
             } catch (error) {
-                node.error(`[Kafka Schema Producer] Failed to get Kafka instance: ${error.message}`, error);
+                node.error(`[Kafka Schema Producer] Failed to get Kafka: ${error.message}`, error);
                 node.status({ fill: "red", shape: "ring", text: `Kafka failed: ${error.message.substring(0, 10)}...` });
                 node.ready = false;
                 node.lastMessageTime = null;
             }
         };
 
-        node.getOrRegisterSchema = async function() {
+        node.getOrRegisterSchema = async function () {
             try {
                 const version = config.schemaVersion && config.schemaVersion.trim() !== '' ? config.schemaVersion.trim() : 'latest';
-                
-                // Check if we have a cached schema for the current version
                 if (node.cachedSchemaId && node.cachedSchemaVersion === version) {
-                    node.debug(`[Kafka Schema Producer] Using cached schema ID: ${node.cachedSchemaId} for version: ${version}`);
+                    node.debug(`[Kafka Schema Producer] Using cached schema ID: ${node.cachedSchemaId}`);
                     node.status({ fill: "blue", shape: "ring", text: `Using cached schema v${version}` });
                     return node.cachedSchemaId;
                 }
 
-                // Cache miss or version changed - fetch schema
-                node.debug(`[Kafka Schema Producer] Cache miss or version changed. Fetching schema for version: ${version}`);
+                node.debug(`[Kafka Schema Producer] Fetching schema for version: ${version}`);
                 node.status({ fill: "blue", shape: "ring", text: "Getting schema..." });
+
                 try {
                     let schemaId;
-                    
                     if (version === 'latest') {
-                        schemaId = await node.schemaRegistry.getLatestSchemaId(config.schemaSubject);
-                        node.debug(`[Kafka Schema Producer] Retrieved latest schema ID: ${schemaId} for subject: ${config.schemaSubject}`);
-                    } else {
-                        // Get specific version
-                        const versionNumber = parseInt(version);
-                        if (isNaN(versionNumber) || versionNumber <= 0) {
-                            throw new Error(`Invalid schema version: ${version}. Must be 'latest' or a positive integer.`);
+                        if (config.autoRegister && config.autoSchema) {
+                            let schemaObject;
+                            try {
+                                schemaObject = JSON.parse(config.autoSchema);
+                            } catch (parseError) {
+                                throw new Error(`Invalid schema JSON: ${parseError.message}`);
+                            }
+                            const registeredSchema = await node.schemaRegistry.register({
+                                type: SchemaType.AVRO,
+                                schema: JSON.stringify(schemaObject)
+                            }, { subject: config.schemaSubject });
+                            schemaId = registeredSchema.id;
+                            node.debug(`[Kafka Schema Producer] Schema auto-registered ID: ${schemaId}`);
+                        } else {
+                            schemaId = await node.schemaRegistry.getLatestSchemaId(config.schemaSubject);
+                            node.debug(`[Kafka Schema Producer] Latest schema ID: ${schemaId}`);
                         }
-                        
-                        schemaId = await node.schemaRegistry.getRegistryId(config.schemaSubject, versionNumber);
-                        node.debug(`[Kafka Schema Producer] Retrieved schema ID: ${schemaId} for subject: ${config.schemaSubject}, version: ${versionNumber}`);
+                    } else {
+                        schemaId = await node.schemaRegistry.getSchemaId(config.schemaSubject, parseInt(version));
+                        node.debug(`[Kafka Schema Producer] Schema ID for v${version}: ${schemaId}`);
                     }
-                    
-                    // Cache the schema ID and version
                     node.cachedSchemaId = schemaId;
                     node.cachedSchemaVersion = version;
-                    node.status({ fill: "blue", shape: "ring", text: `Schema v${version} retrieved` });
+                    node.status({ fill: "blue", shape: "ring", text: `Schema v${version} cached` });
                     return schemaId;
-                } catch (error) {
-                    node.debug(`[Kafka Schema Producer] Schema not found: ${error.message}`);
-                    
-                    // If auto-register is enabled, register the schema
-                    if (config.autoRegister && config.autoSchema) {
-                        // Only allow auto-registration for 'latest' version
-                        if (version !== 'latest') {
-                            throw new Error(`Cannot auto-register schema for specific version ${version}. Auto-registration only works with 'latest' version.`);
-                        }
-                        
-                        node.debug(`[Kafka Schema Producer] Auto-registering schema for subject: ${config.schemaSubject}`);
-                        node.status({ fill: "blue", shape: "ring", text: "Registering schema..." });
-                        
-                        let schemaObject;
-                        try {
-                            schemaObject = JSON.parse(config.autoSchema);
-                        } catch (parseError) {
-                            throw new Error(`Invalid schema JSON: ${parseError.message}`);
-                        }
-
-                        const registeredSchema = await node.schemaRegistry.register({
-                            type: 'AVRO',
-                            schema: JSON.stringify(schemaObject)
-                        }, {
-                            subject: config.schemaSubject
-                        });
-                        
-                        // Cache the registered schema
-                        node.cachedSchemaId = registeredSchema.id;
-                        node.cachedSchemaVersion = version;
-                        node.debug(`[Kafka Schema Producer] Registered new schema with ID: ${registeredSchema.id}`);
-                        node.status({ fill: "blue", shape: "ring", text: "Schema registered" });
-                        return registeredSchema.id;
-                    } else {
-                        throw new Error(`Schema not found for subject ${config.schemaSubject}, version ${version}, and auto-register is disabled`);
-                    }
+                } catch (fetchError) {
+                    node.error(`[Kafka Schema Producer] Failed to get/register schema: ${fetchError.message}`);
+                    throw fetchError;
                 }
             } catch (error) {
                 node.error(`[Kafka Schema Producer] Schema operation failed: ${error.message}`);
@@ -240,185 +217,183 @@ module.exports = function (RED) {
             }
         };
 
+        node.encodeProtobuf = function (messageData) {
+            if (!node.protobufType) {
+                throw new Error('Protobuf type not loaded. Check your .proto schema definition.');
+            }
+            const errMsg = node.protobufType.verify(messageData);
+            if (errMsg) {
+                throw new Error(`Protobuf validation error: ${errMsg}`);
+            }
+            const protoMessage = node.protobufType.create(messageData);
+            return Buffer.from(node.protobufType.encode(protoMessage).finish());
+        };
+
         node.on('input', async function (msg) {
-            const nodeType = config.useSchemaValidation ? 'Schema Producer' : 'Producer';
+            const serializationType = config.serializationType || 'avro';
+            const nodeType = config.useSchemaValidation
+                ? (serializationType === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
+                : 'Producer';
             node.debug(`[Kafka ${nodeType}] Received input message`);
-            
+
             if (!node.ready) {
-                node.warn(`[Kafka ${nodeType}] Producer not ready, discarding message`);
-                node.status({ fill: "yellow", shape: "ring", text: "Not ready" });
+                node.warn(`[Kafka ${nodeType}] Producer not ready, skipping message`);
                 return;
             }
 
             try {
                 let messageData = msg.payload;
-                let encodedMessage;
-                let schemaId = null;
 
-                // Handle schema validation if enabled
-                if (config.useSchemaValidation) {
-                    node.status({ fill: "blue", shape: "dot", text: "Validating schema" });
-                    
-                    // Get or register schema
-                    schemaId = await node.getOrRegisterSchema();
-                    
-                    // Prepare message data for schema validation
+                if (typeof messageData === 'string') {
+                    try { messageData = JSON.parse(messageData); } catch (e) { /* keep as string */ }
+                }
+
+                if (iotOptions && iotOptions.useiot) {
                     if (typeof messageData === 'string') {
                         try {
                             messageData = JSON.parse(messageData);
                         } catch (parseError) {
-                            node.error(`[Kafka Schema Producer] Failed to parse message payload as JSON: ${parseError.message}`);
+                            node.error(`[Kafka ${nodeType}] Failed to parse payload as JSON: ${parseError.message}`);
                             node.status({ fill: "red", shape: "ring", text: "Parse error" });
                             return;
                         }
                     }
+                    const nameTypes = getNameTypes(iotOptions.fields);
+                    const msgValues = getMsgValues(messageData, iotOptions.fields);
+                    messageData = {
+                        mc: iotOptions.model,
+                        dc: iotOptions.device,
+                        type: iotOptions.iotType,
+                        nameTypes: nameTypes,
+                        ts: [new Date().getTime()],
+                        values: [msgValues]
+                    };
+                    node.debug(`[Kafka Producer] IoT formatted message:`, messageData);
+                }
 
-                    node.debug(`[Kafka Schema Producer] Message data to validate:`, messageData);
+                let serializedValue;
 
-                    // Encode message with schema validation
-                    node.status({ fill: "blue", shape: "dot", text: "Encoding message" });
-                    try {
-                        encodedMessage = await node.schemaRegistry.encode(schemaId, messageData);
-                        node.debug(`[Kafka Schema Producer] Message validated and encoded successfully`);
-                    } catch (encodeError) {
-                        node.error(`[Kafka Schema Producer] Schema validation failed: ${encodeError.message}`);
-                        node.status({ fill: "red", shape: "ring", text: "Validation failed" });
-                        node.send([null, { payload: { error: encodeError.message, data: messageData } }]);
-                        return;
-                    }
+                if (config.useSchemaValidation) {
+                    if (serializationType === 'protobuf') {
+                        node.debug(`[Kafka Protobuf Producer] Encoding with Protobuf`);
+                        node.status({ fill: "blue", shape: "dot", text: "Encoding (protobuf)" });
 
-                    // If validate-only mode, return the validated data without publishing
-                    if (config.validateOnly) {
-                        node.debug(`[Kafka Schema Producer] Validation-only mode, not publishing to Kafka`);
-                        node.messageCount++;
-                        node.status({ fill: "green", shape: "dot", text: `Validated ${node.messageCount} messages` });
-                        msg.payload = { 
-                            validated: true, 
-                            schemaId: schemaId, 
-                            originalData: messageData,
-                            encodedSize: encodedMessage.length
-                        };
-                        node.send(msg);
-                        return;
+                        if (config.validateOnly) {
+                            const errMsg = node.protobufType ? node.protobufType.verify(messageData) : 'Protobuf type not loaded';
+                            if (errMsg) {
+                                node.warn(`[Kafka Protobuf Producer] Validation failed: ${errMsg}`);
+                                node.status({ fill: "yellow", shape: "ring", text: "Validation failed" });
+                                msg.payload = { validated: false, error: errMsg };
+                                node.send(msg);
+                                return;
+                            }
+                            node.status({ fill: "green", shape: "ring", text: "Validated (not sent)" });
+                            msg.payload = { validated: true };
+                            node.send(msg);
+                            return;
+                        }
+
+                        serializedValue = node.encodeProtobuf(messageData);
+                        node.debug(`[Kafka Protobuf Producer] Encoded to ${serializedValue.length} bytes`);
+                    } else {
+                        node.debug(`[Kafka Schema Producer] Encoding with Avro`);
+                        node.status({ fill: "blue", shape: "dot", text: "Encoding message" });
+
+                        const schemaId = await node.getOrRegisterSchema();
+
+                        if (config.validateOnly) {
+                            try {
+                                await node.schemaRegistry.encode(schemaId, messageData);
+                                node.status({ fill: "green", shape: "ring", text: "Validated (not sent)" });
+                                msg.payload = { validated: true, schemaId };
+                                node.send(msg);
+                            } catch (validationError) {
+                                node.warn(`[Kafka Schema Producer] Validation failed: ${validationError.message}`);
+                                node.status({ fill: "yellow", shape: "ring", text: "Validation failed" });
+                                msg.payload = { validated: false, error: validationError.message };
+                                node.send(msg);
+                            }
+                            return;
+                        }
+
+                        serializedValue = await node.schemaRegistry.encode(schemaId, messageData);
+                        node.debug(`[Kafka Schema Producer] Encoded with schema ID: ${schemaId}`);
                     }
                 } else {
-                    // No schema validation - handle IoT formatting and prepare message
-                    node.status({ fill: "blue", shape: "dot", text: "Preparing message" });
-                    
-                    if (iotOptions.useiot) {
-                        if (msg.broker && msg.broker.model && msg.broker.device) {
-                            iotOptions.model = msg.broker.model;
-                            iotOptions.device = msg.broker.device;
-                        }
-                        
-                        const nameTypes = getNameTypes(iotOptions.fields);
-                        const msgValues = getMsgValues(messageData, iotOptions.fields);
-                        
-                        messageData = {
-                            mc: iotOptions.model,
-                            dc: iotOptions.device,
-                            type: iotOptions.iotType,
-                            nameTypes: nameTypes,
-                            ts: [new Date().getTime()],
-                            values: [msgValues]
-                        };
-                        
-                        node.debug(`[Kafka Producer] IoT formatted message:`, messageData);
-                    }
-                    
-                    // For non-schema mode, serialize message as JSON
-                    if (typeof messageData === 'object') {
-                        encodedMessage = JSON.stringify(messageData);
-                    } else {
-                        encodedMessage = messageData;
-                    }
+                    serializedValue = typeof messageData === 'string' ? messageData : JSON.stringify(messageData);
                 }
 
-                // Prepare Kafka message
-                const kafkaMessage = {
-                    topic: config.topic,
-                    messages: [
-                        {
-                            key: msg.key || (messageData && messageData.id ? messageData.id.toString() : null),
-                            value: encodedMessage,
-                            timestamp: msg.timestamp || Date.now().toString(),
-                            headers: msg.headers || {}
-                        },
-                    ],
-                };
+                const topic = msg.topic || config.topic;
+                const kafkaMessage = { value: serializedValue };
 
-                // Apply compression if configured (attributes: 0=None, 1=GZIP, 2=Snappy, 3=LZ4)
-                if (config.attributes && config.attributes > 0) {
-                    kafkaMessage.compression = config.attributes;
-                    node.debug(`[Kafka ${nodeType}] Using compression type: ${config.attributes}`);
+                if (msg.key !== undefined) {
+                    kafkaMessage.key = typeof msg.key === 'string' ? msg.key : JSON.stringify(msg.key);
+                } else if (config.messageKey && config.messageKey.trim() !== '') {
+                    kafkaMessage.key = config.messageKey.trim();
                 }
 
-                // Send to Kafka
-                node.status({ fill: "blue", shape: "dot", text: "Sending to Kafka" });
-                node.debug(`[Kafka ${nodeType}] Publishing message to topic: ${config.topic}`);
-                const result = await node.producer.send(kafkaMessage);
-                
-                node.debug(`[Kafka ${nodeType}] Message published successfully`);
-                node.lastMessageTime = new Date().getTime();
+                if (msg.headers && typeof msg.headers === 'object') {
+                    kafkaMessage.headers = msg.headers;
+                }
+
+                node.debug(`[Kafka ${nodeType}] Sending message to topic: ${topic}`);
+                node.status({ fill: "blue", shape: "dot", text: "Sending..." });
+
+                const compressionType = config.compressionType !== undefined ? Number(config.compressionType) : CompressionTypes.None;
+
+                await node.producer.send({
+                    topic: topic,
+                    compression: compressionType,
+                    messages: [kafkaMessage]
+                });
+
                 node.messageCount++;
-                node.status({ fill: "green", shape: "dot", text: `Sent ${node.messageCount} messages` });
-                
-                // Send success response
-                const responsePayload = {
-                    success: true,
-                    kafkaResult: result,
-                    originalData: messageData,
-                    topic: config.topic
+                node.lastMessageTime = new Date().getTime();
+
+                const serTag = config.useSchemaValidation ? (serializationType === 'protobuf' ? ' [protobuf]' : ' [avro]') : '';
+                node.status({ fill: "green", shape: "dot", text: `Sent${serTag} #${node.messageCount}` });
+                node.debug(`[Kafka ${nodeType}] Sent OK. Count: ${node.messageCount}`);
+
+                msg.payload = {
+                    topic,
+                    messageCount: node.messageCount,
+                    timestamp: node.lastMessageTime,
+                    serialization: config.useSchemaValidation ? (serializationType === 'protobuf' ? 'protobuf' : 'avro') : 'none'
                 };
-                
-                if (config.useSchemaValidation) {
-                    responsePayload.schemaId = schemaId;
-                }
-                
-                msg.payload = responsePayload;
                 node.send(msg);
 
             } catch (error) {
-                const nodeType = config.useSchemaValidation ? 'Schema Producer' : 'Producer';
-                node.error(`[Kafka ${nodeType}] Error processing message: ${error.message}`, error);
+                const nt = config.useSchemaValidation
+                    ? ((config.serializationType || 'avro') === 'protobuf' ? 'Protobuf Producer' : 'Schema Producer')
+                    : 'Producer';
+                node.error(`[Kafka ${nt}] Error: ${error.message}`, error);
                 node.status({ fill: "red", shape: "ring", text: `Error: ${error.message.substring(0, 15)}...` });
                 node.lastMessageTime = null;
-                node.send([null, { payload: { error: error.message, originalMessage: msg } }]);
             }
         });
 
-        // Function to check for idle state and update status
-        function checkLastMessageTime() {
-            if (node.lastMessageTime != null && node.ready) {
-                const timeDiff = new Date().getTime() - node.lastMessageTime;
-                if (timeDiff > 5000) {
-                    const idleSeconds = Math.floor(timeDiff/1000);
-                    const countText = node.messageCount > 0 ? ` (${node.messageCount} sent)` : '';
-                    node.debug(`[Kafka Schema Producer] Producer idle for ${timeDiff}ms`);
-                    node.status({ fill: "yellow", shape: "ring", text: `Idle ${idleSeconds}s${countText}` });
-                }
+        node.checkLastMessageTime = function () {
+            if (node.lastMessageTime) {
+                const timeSince = new Date().getTime() - node.lastMessageTime;
+                const minutes = Math.floor(timeSince / 60000);
+                const seconds = Math.floor((timeSince % 60000) / 1000);
+                const serializationType = config.serializationType || 'avro';
+                const serTag = config.useSchemaValidation ? ` [${serializationType}]` : '';
+                node.status({ fill: "green", shape: "ring", text: `Ready${serTag} | Last: ${minutes}m ${seconds}s | Count: ${node.messageCount}` });
             }
-        }
-
-        // Start idle monitoring
-        node.interval = setInterval(checkLastMessageTime, 1000);
+        };
 
         node.on('close', function (done) {
-            node.debug(`[Kafka Schema Producer] Closing node`);
+            node.debug(`[Kafka Producer] Node closing`);
             node.ready = false;
-            node.status({});
-            node.lastMessageTime = null;
-            node.messageCount = 0;
-            node.cachedSchemaId = null;
-            node.cachedSchemaVersion = null;
-            clearInterval(node.interval);
-            
+            node.protobufType = null;
+            node.protobufRoot = null;
             if (node.producer) {
                 node.producer.disconnect().then(() => {
-                    node.debug(`[Kafka Schema Producer] Producer disconnected`);
+                    node.debug(`[Kafka Producer] Producer disconnected`);
                     done();
                 }).catch(error => {
-                    node.error(`[Kafka Schema Producer] Error disconnecting producer: ${error.message}`);
+                    node.error(`[Kafka Producer] Error disconnecting: ${error.message}`);
                     done();
                 });
             } else {
@@ -426,9 +401,8 @@ module.exports = function (RED) {
             }
         });
 
-        // Initialize the node
         node.init();
     }
 
-    RED.nodes.registerType("oriolrius-kafka-producer", KafkaProducerNode);
+    RED.nodes.registerType('oriolrius-kafka-producer', KafkaProducerNode);
 };

--- a/js/kafka-producer.js
+++ b/js/kafka-producer.js
@@ -1,3 +1,11 @@
+/*
+ * Copyright 2025 Oriol Rius
+ * Copyright 2026 Yehor Roshcha
+ *
+ * This file contains original MIT-licensed work and Apache-2.0-licensed fork
+ * modifications. See LICENSE, LICENSE-MIT, LICENSE-APACHE, and NOTICE.
+ * SPDX-License-Identifier: MIT AND Apache-2.0
+ */
 module.exports = function (RED) {
     const { SchemaRegistry, SchemaType } = require('@kafkajs/confluent-schema-registry');
     const { CompressionTypes, CompressionCodecs } = require('kafkajs');

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,5 +1,3 @@
-
-
 module.exports = {
     getNameTypes: (fields = []) => {
         console.log(`[Utils] Processing ${fields.length} field definitions`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.1",
+    "version": "6.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.1",
+            "version": "6.2.4",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,19 @@
 {
-    "name": "@oriolrius/node-red-contrib-kafka",
-    "version": "5.1.1",
+    "name": "@yroshcha/node-red-contrib-kafka",
+    "version": "6.2.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
-            "name": "@oriolrius/node-red-contrib-kafka",
-            "version": "5.1.1",
+            "name": "@yroshcha/node-red-contrib-kafka",
+            "version": "6.2.1",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",
                 "kafkajs": "^2.2.4",
                 "kafkajs-lz4": "^1.2.1",
-                "kafkajs-snappy": "^1.1.0"
+                "kafkajs-snappy": "^1.1.0",
+                "protobufjs": "^7.4.0"
             },
             "devDependencies": {
                 "dotenv": "^17.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.4",
+    "version": "6.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.4",
+            "version": "6.2.5",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.6",
+    "version": "6.2.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.6",
+            "version": "6.2.7",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.5",
+    "version": "6.2.6",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.5",
+            "version": "6.2.6",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.8",
+    "version": "6.2.9",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.8",
+            "version": "6.2.9",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.9",
+    "version": "6.2.10",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.9",
+            "version": "6.2.10",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.7",
+    "version": "6.2.8",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@yroshcha/node-red-contrib-kafka",
-            "version": "6.2.7",
+            "version": "6.2.8",
             "license": "MIT",
             "dependencies": {
                 "@kafkajs/confluent-schema-registry": "^3.9.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oriolrius/node-red-contrib-kafka",
-    "version": "6.1.1",
+    "version": "6.2.0",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.1",
+    "version": "6.2.2",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.2",
+    "version": "6.2.4",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-    "name": "@oriolrius/node-red-contrib-kafka",
+    "name": "@yroshcha/node-red-contrib-kafka",
     "version": "6.2.1",
-    "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS",
+    "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",
         "nodes": {
-            "oriolrius-kafka-broker": "./js/kafka-broker.js",
-            "oriolrius-kafka-producer": "./js/kafka-producer.js",
-            "oriolrius-kafka-consumer": "./js/kafka-consumer.js",
-            "oriolrius-kafka-history-reader": "./js/kafka-history-reader.js"
+            "yroshcha-kafka-broker": "./js/kafka-broker.js",
+            "yroshcha-kafka-producer": "./js/kafka-producer.js",
+            "yroshcha-kafka-consumer": "./js/kafka-consumer.js",
+            "yroshcha-kafka-history-reader": "./js/kafka-history-reader.js"
         },
         "keywords": [
             "node-red",
@@ -17,6 +17,8 @@
             "kafka-broker",
             "kafka-history",
             "kafkajs",
+            "protobuf",
+            "schema-registry",
             "big-data",
             "node-red-contrib"
         ]
@@ -30,18 +32,26 @@
         "node-red",
         "kafka-broker",
         "kafkajs",
+        "protobuf",
+        "schema-registry",
         "big-data",
         "data"
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/oriolrius/node-red-contrib-kafka"
+        "url": "https://github.com/YRoshcha/node-red-contrib-kafka"
     },
     "bugs": {
-        "url": "https://github.com/oriolrius/node-red-contrib-kafka/issues"
+        "url": "https://github.com/YRoshcha/node-red-contrib-kafka/issues"
     },
-    "homepage": "https://github.com/oriolrius/node-red-contrib-kafka/blob/main/README.md",
+    "homepage": "https://github.com/YRoshcha/node-red-contrib-kafka/blob/main/README.md",
     "author": "oriolrius",
+    "contributors": [
+        {
+            "name": "YRoshcha",
+            "url": "https://github.com/YRoshcha"
+        }
+    ],
     "publishConfig": {
         "access": "public"
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.4",
+    "version": "6.2.5",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@oriolrius/node-red-contrib-kafka",
-    "version": "6.2.0",
+    "version": "6.2.1",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,8 @@
         "@kafkajs/confluent-schema-registry": "^3.9.0",
         "kafkajs": "^2.2.4",
         "kafkajs-lz4": "^1.2.1",
-        "kafkajs-snappy": "^1.1.0"
+        "kafkajs-snappy": "^1.1.0",
+        "protobufjs": "^7.4.0"
     },
     "devDependencies": {
         "dotenv": "^17.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.8",
+    "version": "6.2.9",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.9",
+    "version": "6.2.10",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     ],
     "repository": {
         "type": "git",
-        "url": "https://github.com/YRoshcha/node-red-contrib-kafka"
+        "url": "git+https://github.com/YRoshcha/node-red-contrib-kafka.git"
     },
     "bugs": {
         "url": "https://github.com/YRoshcha/node-red-contrib-kafka/issues"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.5",
+    "version": "6.2.6",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.6",
+    "version": "6.2.7",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@yroshcha/node-red-contrib-kafka",
-    "version": "6.2.7",
+    "version": "6.2.8",
     "description": "Node-RED Kafka nodes: Send, Receive, and Schema validation with modern KafkaJS. Fork of @oriolrius/node-red-contrib-kafka adding Protobuf + Confluent Schema Registry support to the producer node.",
     "node-red": {
         "version": ">=3.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "publishConfig": {
         "access": "public"
     },
-    "license": "MIT",
+    "license": "MIT AND Apache-2.0",
     "scripts": {
         "test": "node tests/run-tests.js",
         "test:simple": "node tests/simple-kafka-test.js",

--- a/tests/e2e/run-e2e-tests.js
+++ b/tests/e2e/run-e2e-tests.js
@@ -150,13 +150,13 @@ async function testBasicProducerConsumer() {
     const flow = [
         {
             id: 'broker-1',
-            type: 'oriolrius-kafka-broker',
+            type: 'yroshcha-kafka-broker',
             name: 'Test Broker',
             hosts: KAFKA_BROKER
         },
         {
             id: 'producer-1',
-            type: 'oriolrius-kafka-producer',
+            type: 'yroshcha-kafka-producer',
             broker: 'broker-1',
             topic: TEST_TOPIC,
             requireAcks: 1,
@@ -167,7 +167,7 @@ async function testBasicProducerConsumer() {
         },
         {
             id: 'consumer-1',
-            type: 'oriolrius-kafka-consumer',
+            type: 'yroshcha-kafka-consumer',
             broker: 'broker-1',
             topic: TEST_TOPIC,
             groupid: 'e2e-test-group',
@@ -241,13 +241,13 @@ async function testCompression() {
         const flow = [
             {
                 id: 'broker-comp',
-                type: 'oriolrius-kafka-broker',
+                type: 'yroshcha-kafka-broker',
                 name: 'Test Broker',
                 hosts: KAFKA_BROKER
             },
             {
                 id: 'producer-comp',
-                type: 'oriolrius-kafka-producer',
+                type: 'yroshcha-kafka-producer',
                 broker: 'broker-comp',
                 topic: COMPRESSION_TOPIC,
                 requireAcks: 1,
@@ -258,7 +258,7 @@ async function testCompression() {
             },
             {
                 id: 'consumer-comp',
-                type: 'oriolrius-kafka-consumer',
+                type: 'yroshcha-kafka-consumer',
                 broker: 'broker-comp',
                 topic: COMPRESSION_TOPIC,
                 groupid: 'e2e-compression-group-' + compression.value,
@@ -311,13 +311,13 @@ async function testMultipleMessages() {
     const flow = [
         {
             id: 'broker-batch',
-            type: 'oriolrius-kafka-broker',
+            type: 'yroshcha-kafka-broker',
             name: 'Test Broker',
             hosts: KAFKA_BROKER
         },
         {
             id: 'producer-batch',
-            type: 'oriolrius-kafka-producer',
+            type: 'yroshcha-kafka-producer',
             broker: 'broker-batch',
             topic: TEST_TOPIC + '-batch',
             requireAcks: 1,
@@ -328,7 +328,7 @@ async function testMultipleMessages() {
         },
         {
             id: 'consumer-batch',
-            type: 'oriolrius-kafka-consumer',
+            type: 'yroshcha-kafka-consumer',
             broker: 'broker-batch',
             topic: TEST_TOPIC + '-batch',
             groupid: 'e2e-batch-group',

--- a/tests/simple-kafka-test.js
+++ b/tests/simple-kafka-test.js
@@ -161,7 +161,7 @@ async function runSimpleKafkaTest() {
         const originalRegisterType = mockRED.nodes.registerType;
         mockRED.nodes.registerType = function(type, constructor) {
             console.log(`✅ Node registered: ${type}`);
-            if (type === 'oriolrius-kafka-producer') {
+            if (type === 'yroshcha-kafka-producer') {
                 KafkaProducerConstructor = constructor;
             }
         };
@@ -217,7 +217,7 @@ async function runSimpleKafkaTest() {
         let KafkaConsumerConstructor = null;
         mockRED.nodes.registerType = function(type, constructor) {
             console.log(`✅ Node registered: ${type}`);
-            if (type === 'oriolrius-kafka-consumer') {
+            if (type === 'yroshcha-kafka-consumer') {
                 KafkaConsumerConstructor = constructor;
             }
         };

--- a/tests/test-compression.js
+++ b/tests/test-compression.js
@@ -71,7 +71,7 @@ const mockRED = {
             return mockBroker;
         },
         registerType: function(type, constructor) {
-            if (type === 'oriolrius-kafka-producer') {
+            if (type === 'yroshcha-kafka-producer') {
                 mockRED._producerConstructor = constructor;
             }
             console.log(`✅ Node registered: ${type}`);

--- a/tests/test-examples.js
+++ b/tests/test-examples.js
@@ -56,7 +56,7 @@ exampleFiles.forEach(file => {
 
     // Test 4: Check for our Kafka nodes
     const kafkaNodes = flow.filter(n =>
-        n.type && n.type.startsWith('oriolrius-kafka-')
+        n.type && n.type.startsWith('yroshcha-kafka-')
     );
     console.log(`  ✅ Found ${kafkaNodes.length} Kafka nodes`);
 
@@ -110,7 +110,7 @@ exampleFiles.forEach(file => {
     // Test 7: Check Kafka node configurations
     let configErrors = 0;
     kafkaNodes.forEach(node => {
-        if (node.type === 'oriolrius-kafka-producer') {
+        if (node.type === 'yroshcha-kafka-producer') {
             if (!node.topic) {
                 console.log(`  ❌ Producer ${node.id}: missing required field 'topic'`);
                 configErrors++;
@@ -125,14 +125,14 @@ exampleFiles.forEach(file => {
             }
         }
 
-        if (node.type === 'oriolrius-kafka-consumer') {
+        if (node.type === 'yroshcha-kafka-consumer') {
             if (!node.topic) {
                 console.log(`  ❌ Consumer ${node.id}: missing required field 'topic'`);
                 configErrors++;
             }
         }
 
-        if (node.type === 'oriolrius-kafka-history-reader') {
+        if (node.type === 'yroshcha-kafka-history-reader') {
             if (!node.topic) {
                 console.log(`  ❌ History Reader ${node.id}: missing required field 'topic'`);
                 configErrors++;

--- a/tests/test-history-reader.js
+++ b/tests/test-history-reader.js
@@ -104,7 +104,7 @@ const RED = {
                 fromOffset: 'earliest',
                 encoding: 'utf8',
                 useSchemaValidation: false,
-                type: 'oriolrius-kafka-history-reader'
+                type: 'yroshcha-kafka-history-reader'
             };
             
             const node = {};

--- a/tests/test-kafka-history-reader.js
+++ b/tests/test-kafka-history-reader.js
@@ -19,7 +19,7 @@ describe('Kafka History Reader Node', function () {
         const flow = [
             { 
                 id: "n1", 
-                type: "oriolrius-kafka-history-reader", 
+                type: "yroshcha-kafka-history-reader", 
                 name: "test history reader",
                 broker: "b1",
                 topic: "test-topic",
@@ -29,7 +29,7 @@ describe('Kafka History Reader Node', function () {
             },
             {
                 id: "b1",
-                type: "oriolrius-kafka-broker",
+                type: "yroshcha-kafka-broker",
                 name: "test broker",
                 hosts: "localhost:9092",
                 clientId: "test-client"
@@ -39,7 +39,7 @@ describe('Kafka History Reader Node', function () {
         helper.load([kafkaBrokerNode, kafkaHistoryReaderNode], flow, function () {
             const n1 = helper.getNode("n1");
             n1.should.have.property('name', 'test history reader');
-            n1.should.have.property('type', 'oriolrius-kafka-history-reader');
+            n1.should.have.property('type', 'yroshcha-kafka-history-reader');
             done();
         });
     });
@@ -48,7 +48,7 @@ describe('Kafka History Reader Node', function () {
         const flow = [
             { 
                 id: "n1", 
-                type: "oriolrius-kafka-history-reader", 
+                type: "yroshcha-kafka-history-reader", 
                 name: "test history reader",
                 broker: "b1",
                 topic: "sensor-data",
@@ -60,7 +60,7 @@ describe('Kafka History Reader Node', function () {
             },
             {
                 id: "b1",
-                type: "oriolrius-kafka-broker",
+                type: "yroshcha-kafka-broker",
                 name: "test broker",
                 hosts: "localhost:9092",
                 clientId: "test-client"
@@ -86,7 +86,7 @@ describe('Kafka History Reader Node', function () {
         const flow = [
             { 
                 id: "n1", 
-                type: "oriolrius-kafka-history-reader", 
+                type: "yroshcha-kafka-history-reader", 
                 name: "test history reader"
                 // Missing required properties: broker, topic, messageTypes
             }
@@ -107,7 +107,7 @@ describe('Kafka History Reader Node', function () {
         const flow = [
             { 
                 id: "n1", 
-                type: "oriolrius-kafka-history-reader", 
+                type: "yroshcha-kafka-history-reader", 
                 name: "test history reader",
                 broker: "b1",
                 topic: "test-topic",
@@ -117,7 +117,7 @@ describe('Kafka History Reader Node', function () {
             },
             {
                 id: "b1",
-                type: "oriolrius-kafka-broker",
+                type: "yroshcha-kafka-broker",
                 name: "test broker",
                 hosts: "localhost:9092",
                 clientId: "test-client"
@@ -172,7 +172,7 @@ describe('Kafka History Reader Node', function () {
         const flow = [
             { 
                 id: "n1", 
-                type: "oriolrius-kafka-history-reader", 
+                type: "yroshcha-kafka-history-reader", 
                 name: "test history reader",
                 broker: "missing-broker",
                 topic: "test-topic",


### PR DESCRIPTION
## Protobuf Serialization Support for Kafka Send Node

### Overview
Added full Protobuf serialization support to the Kafka Send (producer) node alongside the existing Avro mode. The node now supports three serialization modes: Avro + Schema Registry (default), Protobuf + Schema Registry (Confluent wire format), and Protobuf Raw (no Schema Registry).

### Changes

#### `js/kafka-producer.js`
- Added `serializationType` config field (`avro` | `protobuf`), defaults to `avro` for backward compatibility
- - Added `protobufMode` config field (`registry` | `raw`) to switch between Confluent SR mode and pure protobufjs mode
- - Added `protobufSchema` and `protobufMessageName` config fields to define the `.proto` schema and root message type
- - Implemented Protobuf encoding using `protobufjs`:
-   - **`registry` mode**: encodes message with Confluent wire format (magic byte `0x00` + 4-byte schema ID + Protobuf message index byte `0x00` patch for Confluent compatibility)
-   - **`raw` mode**: encodes message as pure protobufjs bytes without Schema Registry
- - Added auto-registration of `.proto` schemas in Confluent Schema Registry when `autoRegister` is enabled
- - Node status badge updated to show `[avro]`, `[proto-sr]`, or `[proto-raw]` depending on active mode
- - Fixed Confluent Protobuf wire format: added the message index byte (`0x00`) after the schema ID header, required for compatibility with Confluent consumers and ksqlDB (v6.2.1 fix)
#### `js/kafka-producer.html`
- Added **Serialization** dropdown (`Avro` / `Protobuf`) to the Schema Validation section
- - Added **Mode** dropdown for Protobuf (`Schema Registry` / `Raw`) — shown only when Protobuf is selected
- - Added **Message Name** input field for the root Protobuf message type name
- - Added **.proto Schema** textarea for inline `.proto` definition
- - For Protobuf + SR mode with auto-register: shows a note that the `.proto` schema defined in the node will be used for registration (instead of Avro JSON schema textarea)
- - Show/hide logic updated: Schema Registry fields appear for both Avro and Protobuf-SR modes; hidden in Protobuf Raw mode
- - Fixed duplicate HTML element IDs and corrected auth fields show/hide behavior
#### `package.json`
- Added `protobufjs: ^7.4.0` as a runtime dependency
- - Bumped version from `6.1.1` → `6.2.0` → `6.2.1`
#### `docs/PROTOBUF_PRODUCER_GUIDE.md` *(new file)*
- Added comprehensive usage guide covering:
-   - Mode comparison table (Avro, Protobuf SR, Protobuf Raw)
-   - UI field descriptions
-   - `msg.payload` format with examples for simple messages, nested messages, repeated fields, and enum fields
-   - Optional per-message overrides (`msg.topic`, `msg.key`)
-   - Output payload format after successful publish
-   - Error handling table
### Versions
- `v6.2.0` — initial Protobuf serialization support
- - `v6.2.1` — fix Confluent Protobuf wire format: add message index byte after schema ID